### PR TITLE
Require ostruct

### DIFF
--- a/lib/disposable/twin/sync.rb
+++ b/lib/disposable/twin/sync.rb
@@ -3,6 +3,7 @@
 #   2. call sync! on nested
 #
 # Note: #sync currently implicitly saves AR objects with collections
+require 'ostruct'
 class Disposable::Twin
   module Sync
     # Creates a fresh copy of the internal representer and adds Representable::Hash.


### PR DESCRIPTION
I got this error while using Trailblazer from the console:

```
NameError: uninitialized constant Disposable::Twin::Sync::SkipGetter::OpenStruct
	from /home/monkbroc/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/disposable-0.1.14/lib/disposable/twin/sync.rb:146:in `nested_hash_source'
	from /home/monkbroc/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/disposable-0.1.14/lib/disposable/twin/sync.rb:66:in `to_nested_hash'
	from /home/monkbroc/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/disposable-0.1.14/lib/disposable/twin/sync.rb:22:in `sync_models'
	from /home/monkbroc/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/disposable-0.1.14/lib/disposable/twin/save.rb:5:in `save'
	from (irb):36:in `block in process'
	from /home/monkbroc/Programming/gems/trailblazer/lib/trailblazer/operation.rb:123:in `validate'
	from (irb):35:in `process'
	from /home/monkbroc/Programming/gems/trailblazer/lib/trailblazer/operation.rb:71:in `run'
	from /home/monkbroc/Programming/gems/trailblazer/lib/trailblazer/operation.rb:34:in `call'
```

The `require 'ostruct'` is missing from this file.