### PR TITLE
Implement :struct options for properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,14 +366,12 @@ Twins can also map hash properties, e.g. from a deeply nested serialized JSON co
 album.permissions #=> {admin: {read: true, write: true}, user: {destroy: false}}
 ```
 
-Map that using the `Struct` module.
+Map that using the `:struct` option that automatically adds `Disposable::Twin::Struct` feature.
 
 ```ruby
 class AlbumTwin < Disposable::Twin
-  property :permissions do
-     include Struct
-    property :admin do
-      include Struct
+  property :permissions, struct: true do
+    property :admin, struct: true do
       property :read
       property :write
     end

--- a/lib/disposable/twin.rb
+++ b/lib/disposable/twin.rb
@@ -44,7 +44,13 @@ module Disposable
 
         options[:nested] = options.delete(:twin) if options[:twin]
 
-        super(name, options, &block).tap do |definition|
+        class_block = proc do
+          require 'disposable/twin/struct'
+          include Disposable::Twin::Struct if options[:struct]
+          class_eval(&block)
+        end if block
+
+        super(name, options, &class_block).tap do |definition|
           create_accessors(name, definition)
         end
       end


### PR DESCRIPTION
Hello, @apotonick! I really appreciate stuff you build (Reform, Roar, etc), it's really game-changing!

I read a [post about Reform 2.0](http://nicksda.apotomo.de/2015/07/reform-2-0-form-objects-for-ruby/) where you mentioned `:struct` option for properties which I found very useful in my tasks. However, I haven't found it implemented nor in Reform neither in Disposable. This patch fills this gap! 
