### PR TITLE
In Twin#create_accessors, don't overwrite existing methods

### DIFF
--- a/lib/disposable/twin.rb
+++ b/lib/disposable/twin.rb
@@ -51,9 +51,9 @@ module Disposable
 
       def create_accessors(name, definition)
         mod = Module.new do
-          define_method(name)       { @fields[name.to_s] }
+          define_method(name)       { defined?(super) ? super() : @fields[name.to_s] }
           # define_method(name)       { read_property(name) }
-          define_method("#{name}=") { |value| write_property(name, value, definition) }
+          define_method("#{name}=") { |value| defined?(super) ? super(value) : write_property(name, value, definition) }
         end
         include mod
       end

--- a/test/twin/inherit_test.rb
+++ b/test/twin/inherit_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class InheritTest < MiniTest::Spec
   module Model
     Song  = Struct.new(:title, :album)
-    Album = Struct.new(:name, :songs, :artist)
+    Album = Struct.new(:name, :songs, :artist, :with_custom_getter, :with_custom_setter)
     Artist = Struct.new(:name)
   end
 
@@ -23,6 +23,17 @@ class InheritTest < MiniTest::Spec
         def artist_id
           1
         end
+      end
+
+      property :with_custom_getter
+      property :with_custom_setter
+
+      def with_custom_getter
+        "my custom getter"
+      end
+
+      def with_custom_setter=(val)
+        super("my custom setter")
       end
     end
 
@@ -54,4 +65,24 @@ class InheritTest < MiniTest::Spec
 
   # inherit inline twins when overriding.
   it { Twin::Compilation.new(album).artist.artist_id.must_equal 1 }
+
+  describe "custom getters get inherited" do
+    let (:album) { Model::Album.new("", [], Model::Artist.new, "this gets ignored", "") }
+
+    it do
+      compilation = Twin::Compilation.new(album)
+      compilation.with_custom_getter.must_equal("my custom getter")
+    end
+  end
+
+  describe "custom setters get inherited" do
+    let (:album) { Model::Album.new("", [], Model::Artist.new, "", "custom setter default") }
+
+    it do
+      compilation = Twin::Compilation.new(album)
+      compilation.with_custom_setter = "custom setter default"
+      compilation.with_custom_setter = "this gets ignored"
+      compilation.with_custom_setter.must_equal("my custom setter")
+    end
+  end
 end

--- a/test/twin/inherit_test.rb
+++ b/test/twin/inherit_test.rb
@@ -29,11 +29,11 @@ class InheritTest < MiniTest::Spec
       property :with_custom_setter
 
       def with_custom_getter
-        "my custom getter"
+        "my custom getter: #{super}"
       end
 
       def with_custom_setter=(val)
-        super("my custom setter")
+        super("my custom setter: #{val}")
       end
     end
 
@@ -67,22 +67,22 @@ class InheritTest < MiniTest::Spec
   it { Twin::Compilation.new(album).artist.artist_id.must_equal 1 }
 
   describe "custom getters get inherited" do
-    let (:album) { Model::Album.new("", [], Model::Artist.new, "this gets ignored", "") }
+    let (:album) { Model::Album.new("", [], Model::Artist.new, "underlying getter value", "") }
 
     it do
       compilation = Twin::Compilation.new(album)
-      compilation.with_custom_getter.must_equal("my custom getter")
+      compilation.with_custom_getter.must_equal("my custom getter: underlying getter value")
     end
   end
 
   describe "custom setters get inherited" do
-    let (:album) { Model::Album.new("", [], Model::Artist.new, "", "custom setter default") }
+    let (:album) { Model::Album.new("", [], Model::Artist.new, "", "underlying setter value") }
 
     it do
       compilation = Twin::Compilation.new(album)
-      compilation.with_custom_setter = "custom setter default"
-      compilation.with_custom_setter = "this gets ignored"
-      compilation.with_custom_setter.must_equal("my custom setter")
+      compilation.with_custom_setter.must_equal("my custom setter: underlying setter value")
+      compilation.with_custom_setter = "new value"
+      compilation.with_custom_setter.must_equal("my custom setter: new value")
     end
   end
 end


### PR DESCRIPTION
Proposed fix for #36.