### PR TITLE
Feature: Use dry-types for coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,14 +187,16 @@ class AlbumTwin < Disposable::Twin
 
 ## Coercion
 
-Twins can use [Virtus](https://github.com/solnic/virtus) coercion. This will override the setter in your twin, coerce the incoming value, and call the original setter. _Nothing more_ will happen.
+Twins can use [dry-types](https://github.com/dry-rb/dry-types) coercion. This will override the setter in your twin, coerce the incoming value, and call the original setter. _Nothing more_ will happen.
+
+Disposable already defines a module `Disposable::Twin::Coercion::Types` with all the Dry::Types built-in types. So you can use any of the types documented in http://dry-rb.org/gems/dry-types/built-in-types/.
 
 ```ruby
 class AlbumTwin < Disposable::Twin
   feature Coercion
   feature Setup::SkipSetter
 
-  property :id, type: Integer
+  property :id, type: Types::Form::Int
 ```
 
 The `:type` option defines the coercion type. You may incluce `Setup::SkipSetter`, too, as otherwise the coercion will happen at initialization time and in the setter.
@@ -205,7 +207,6 @@ twin.id #=> 1
 ```
 
 Again, coercion only happens in the setter.
-
 
 ## Defaults
 

--- a/disposable.gemspec
+++ b/disposable.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "activerecord"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "virtus"
+  spec.add_development_dependency "dry-types", "~> 0.6"
   # spec.add_development_dependency "database_cleaner"
 end

--- a/lib/disposable/twin/coercion.rb
+++ b/lib/disposable/twin/coercion.rb
@@ -8,11 +8,12 @@ module Disposable::Twin::Coercion
   module ClassMethods
     def property(name, options={}, &block)
       super(name, options, &block).tap do
-        coercing_setter!(name, options[:type]) if options[:type]
+        coercing_setter!(name, options[:type], options[:nilify]) if options[:type]
       end
     end
 
-    def coercing_setter!(name, type)
+    def coercing_setter!(name, type, nilify = false)
+      type = (Types::Form::Nil | type) if nilify
       mod = Module.new do
         define_method("#{name}=") do |value|
           super type.call(value)

--- a/lib/disposable/twin/coercion.rb
+++ b/lib/disposable/twin/coercion.rb
@@ -1,17 +1,22 @@
-require "virtus"
+require 'dry-types'
 
-# confession: i love virtus' coercion.
 module Disposable::Twin::Coercion
+  module Types
+    include Dry::Types.module
+  end
+
   module ClassMethods
     def property(name, options={}, &block)
       super(name, options, &block).tap do
-        coercing_setter!(name, options[:type])  # define coercing setter after twin.
+        coercing_setter!(name, options[:type]) if options[:type]
       end
     end
 
     def coercing_setter!(name, type)
       mod = Module.new do
-        define_method("#{name}=") { |value| super Virtus::Attribute.build(type).coerce(value) }
+        define_method("#{name}=") do |value|
+          super type.call(value)
+        end
       end
       include mod
     end

--- a/test/twin/changed_test.rb
+++ b/test/twin/changed_test.rb
@@ -114,24 +114,23 @@ class ChangedWithCoercionTest < MiniTest::Spec
     include Changed
     include Coercion
 
-    property :released, type: Virtus::Attribute::Boolean
+    property :released, type: Types::Form::Bool
   end
 
   it do
     twin = SongTwin.new(Song.new)
     twin.changed?(:released).must_equal false
-    twin.released = 1
+    twin.released = 'true'
     twin.released.must_equal true
     twin.changed?(:released).must_equal true
   end
 
   it do
     twin = SongTwin.new(Song.new(true))
-    twin.released = true
     twin.changed?(:released).must_equal false
-    twin.released = 1 # it coerces, then assigns, then compares, which makes this NOT changed.
+    twin.released = 'true' # it coerces, then assigns, then compares, which makes this NOT changed.
     twin.changed?(:released).must_equal false
-    twin.released = false
+    twin.released = 'false'
     twin.changed?(:released).must_equal true
   end
 end

--- a/test/twin/coercion_test.rb
+++ b/test/twin/coercion_test.rb
@@ -3,84 +3,77 @@ require "test_helper"
 require "disposable/twin/coercion"
 
 class CoercionTest < MiniTest::Spec
-  Band = Struct.new(:label)
 
-  class Irreversible < Virtus::Attribute
-    def coerce(value)
-      value*2
-    end
-  end
-
-  class Twin < Disposable::Twin
+  class TwinWithSkipSetter < Disposable::Twin
     feature Coercion
     feature Setup::SkipSetter
 
     property :id
-    property :released_at, :type => DateTime
+    property :released_at, :type => Types::Form::DateTime
 
     property :hit do
-      property :length, :type => Integer
-      property :good,   :type => Virtus::Attribute::Boolean
+      property :length, :type => Types::Coercible::Int
+      property :good,   :type => Types::Bool
     end
 
     property :band do
       property :label do
-        property :value, :type => Irreversible
+        property :value, :type => Types::Coercible::Float
       end
     end
   end
 
-  subject do
-    Twin.new(album)
+  class TwinWithoutSkipSetter < Disposable::Twin
+    feature Coercion
+    property :id, type: Types::Coercible::Int
   end
 
-  let (:album) {
-    OpenStruct.new(
-      id: 1,
-      :released_at => "31/03/1981",
-      :hit         => OpenStruct.new(:length => "312"),
-      :band        => Band.new(OpenStruct.new(:value => "9999.99"))
-    )
-  }
+  describe "with Setup::SkipSetter" do
 
-  # it { subject.released_at.must_be_kind_of DateTime }
-  it { subject.released_at.must_equal "31/03/1981" } # NO coercion in setup.
-  it { subject.hit.length.must_equal "312" }
-  it { subject.band.label.value.must_equal "9999.99" }
+    subject do
+      TwinWithSkipSetter.new(album)
+    end
 
+    let (:album) {
+      OpenStruct.new(
+        id: 1,
+        :released_at => "31/03/1981",
+        :hit         => OpenStruct.new(:length => "312"),
+        :band        => OpenStruct.new(:label => OpenStruct.new(:value => "9999.99"))
+      )
+    }
 
-  it do
-    subject.id = Object
-    subject.released_at = "30/03/1981"
-    subject.hit.length = "312"
-    subject.band.label.value = "9999.99"
-
-    subject.id = Object
-    subject.released_at.must_be_kind_of DateTime
-    subject.released_at.must_equal DateTime.parse("30/03/1981")
-    subject.hit.length.must_equal 312
-    subject.hit.good.must_equal nil
-    subject.band.label.value.must_equal "9999.999999.99" # coercion happened once.
-  end
-end
+    it "NOT coerce values in setup" do
+      subject.released_at.must_equal "31/03/1981"
+      subject.hit.length.must_equal "312"
+      subject.band.label.value.must_equal "9999.99"
+    end
 
 
-class CoercionWithoutSkipSetterTest < MiniTest::Spec
-  class Irreversible < Virtus::Attribute
-    def coerce(value)
-      value*2
+    it "coerce values when using a setter" do
+      subject.id = Object
+      subject.released_at = "30/03/1981"
+      subject.hit.length = "312"
+      subject.band.label.value = "9999.99"
+
+      subject.released_at.must_be_kind_of DateTime
+      subject.released_at.must_equal DateTime.parse("30/03/1981")
+      subject.hit.length.must_equal 312
+      subject.hit.good.must_equal nil
+      subject.band.label.value.must_equal 9999.99
     end
   end
 
-  class Twin < Disposable::Twin
-    feature Coercion
-    property :id, type: Irreversible
-  end
+  describe "without Setup::SkipSetter" do
 
-  it do
-    twin = Twin.new(OpenStruct.new(id: "1"))
-    twin.id.must_equal "11" # coercion happens in Setup.
-    twin.id = "2"
-    twin.id.must_equal "22"
+    subject do
+      TwinWithoutSkipSetter.new(OpenStruct.new(id: "1"))
+    end
+
+    it "coerce values in setup and when using a setter" do
+      subject.id.must_equal 1
+      subject.id = "2"
+      subject.id.must_equal 2
+    end
   end
 end

--- a/test/twin/coercion_test.rb
+++ b/test/twin/coercion_test.rb
@@ -28,6 +28,15 @@ class CoercionTest < MiniTest::Spec
     property :id, type: Types::Coercible::Int
   end
 
+  class TwinWithNilify < Disposable::Twin
+    feature Coercion
+
+    property :date_of_birth,
+             type: Types::Form::Date, nilify: true
+    property :date_of_death_by_unicorns,
+             type: Types::Form::Nil | Types::Form::Date
+  end
+
   describe "with Setup::SkipSetter" do
 
     subject do
@@ -74,6 +83,29 @@ class CoercionTest < MiniTest::Spec
       subject.id.must_equal 1
       subject.id = "2"
       subject.id.must_equal 2
+    end
+  end
+
+  describe "with Nilify" do
+
+    subject do
+      TwinWithNilify.new(OpenStruct.new(date_of_birth: '1990-01-12',
+                                        date_of_death_by_unicorns: '2037-02-18'))
+    end
+
+    it "coerce values correctly" do
+      subject.date_of_birth.must_equal Date.parse('1990-01-12')
+      subject.date_of_death_by_unicorns.must_equal Date.parse('2037-02-18')
+    end
+
+    it "coerce empty values to nil when using option nilify: true" do
+      subject.date_of_birth = ''
+      subject.date_of_birth.must_equal nil
+    end
+
+    it "coerce empty values to nil when using dry-types | operator" do
+      subject.date_of_death_by_unicorns = ''
+      subject.date_of_death_by_unicorns.must_equal nil
     end
   end
 end


### PR DESCRIPTION
Using `dry-types` instead of `virtus` for coercion.

Everything seems fine.