### PR TITLE
Add :accessor for avoiding defining accessors

### DIFF
--- a/lib/disposable/twin.rb
+++ b/lib/disposable/twin.rb
@@ -34,6 +34,7 @@ module Disposable
       def property(name, options={}, &block)
         options[:private_name] ||= options.delete(:from) || name
         is_inherited = options.delete(:_inherited)
+        define_accessor = options.delete(:accessor)
 
         if options.delete(:virtual)
           options[:writeable] = options[:readable] = false
@@ -42,7 +43,7 @@ module Disposable
         options[:nested] = options.delete(:twin) if options[:twin]
 
         super(name, options, &block).tap do |definition| # super is Declarative::Schema::property.
-          create_accessors(name, definition) unless is_inherited
+          create_accessors(name, definition) unless is_inherited || define_accessor == false
         end
       end
 

--- a/test/twin/accessor_test.rb
+++ b/test/twin/accessor_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class AccessorTest < MiniTest::Spec
+  Song = Struct.new(:title)
+
+  class SongForm < Disposable::Twin
+    def title
+      @title
+    end
+
+    def title=(value)
+      @title = value.reverse if value
+    end
+
+    property :title, accessor: false
+  end
+
+  let (:song) { Song.new }
+
+  let (:twin) { SongForm.new(song) }
+
+  it {
+    twin.title = "Remedy"
+    twin.title.must_equal "ydemeR"
+  }
+end


### PR DESCRIPTION
If we have an accessor defined before declaring a property in an included module, it will get overriden. The `:accessor` option allows us to specify whether we want Disposable::Twin to define accessors for that property.

```rb
module Titleable
  def title
    # ...
  end

  def title=(value)
    # ...
  end
end

class Song < Disposable::Twin
  include Titleable
  property :title, accessor: false
end
```

I know this is probably a fairly uncommon scenario, but I needed this in [Shrine](https://github.com/janko-m/shrine).