### PR TITLE
Adds test for double coercion bug on subclasses

### DIFF
--- a/test/twin/coercion_test.rb
+++ b/test/twin/coercion_test.rb
@@ -44,6 +44,14 @@ class CoercionTest < MiniTest::Spec
       subject.band.label.value.must_equal "9999.99"
     end
 
+    it "NOT coerce twice on subclasses" do
+      subclassed = Class.new(TwinWithSkipSetter).new(album)
+      subclassed.released_at.must_equal "31/03/1981"
+
+      subclassed.released_at =  "12/12/1980"
+      subclassed.released_at.must_equal DateTime.parse("12/12/1980")
+    end
+
 
     it "coerce values when using a setter" do
       subject.id = Object


### PR DESCRIPTION
Hi,
After the switch from `Virtus` to `DryTypes` we get coercion errors on subclasses. The setter [here](https://github.com/apotonick/disposable/blob/master/lib/disposable/twin/coercion.rb#L20) gets called twice then, the first time with the string, the second time with an already coerced value and results in a `TypeError`.
In this pull request I added a test simulating this behaviour.

Thank you

Andreas