### PR TITLE
Make dry types a runtime dependency, not just a development dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Make dry types a runtime dependency, not just a development dependency
+
 # 0.3.2
 
 * Rename `JSONB` to `Property::Hash`.

--- a/disposable.gemspec
+++ b/disposable.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency "uber"
   spec.add_dependency "declarative", ">= 0.0.8", "< 1.0.0"
   spec.add_dependency "representable", ">= 2.4.0", "<= 3.1.0"
+  spec.add_dependency "dry-types", "~> 0.6"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "activerecord"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "dry-types", "~> 0.6"
   # spec.add_development_dependency "database_cleaner"
 end


### PR DESCRIPTION
It is required in non-development contexts