### PR TITLE
Use instance_eval, so property can be a private method

### DIFF
--- a/lib/disposable/twin/parent.rb
+++ b/lib/disposable/twin/parent.rb
@@ -1,6 +1,6 @@
 module Disposable::Twin::Parent
   def self.included(includer)
-    includer.property(:parent, virtual: true)
+    includer.instance_eval { property(:parent, virtual: true) }
   end
 
   # FIXME: for collections, this will merge options for every element.


### PR DESCRIPTION
When using Disposable::Twin::Parent with Reform::Form::ActiveModel, it fails because property is a private method. Switching from calling property on the includer to instance_eval'ing the property call allows for property to remain private Disposable::Twin::Parent to still work in that case. 
