### PR TITLE
changed scope of `Twin#save!` to protected.

### DIFF
--- a/lib/disposable/twin/save.rb
+++ b/lib/disposable/twin/save.rb
@@ -8,6 +8,7 @@ class Disposable::Twin
       save!(options)
     end
 
+  protected
     def save!(options={})
       result = save_model
 

--- a/test/twin/save_test.rb
+++ b/test/twin/save_test.rb
@@ -154,6 +154,11 @@ class SaveTest < MiniTest::Spec
     album.artist.saved?.must_equal true
   end
 
+  # save!: can not use as public.
+  it do
+    twin.respond_to?(:save!).must_equal false
+  end
+
   def fill_out!(twin)
     twin.name = "Live And Dangerous"
     twin.songs[0].title = "Southbound"


### PR DESCRIPTION
Hi.

I'm using Reform to my project together with rails.
And I confused about `Twin#save!` method. Because it's completely difference as ActiveRecord's `save!`.

And it seems changeable to `protected` scope.
I think, that change helps understanding of beginners.
Like me 😉 

Thank you.