### PR TITLE
Fix indifferent attribute access

### DIFF
--- a/lib/disposable/twin/property/struct.rb
+++ b/lib/disposable/twin/property/struct.rb
@@ -6,7 +6,7 @@ class Disposable::Twin
     module Struct
       def read_value_for(dfn, options)
         name = dfn[:name]
-        @model[name.to_s] || @model[name.to_sym] # TODO: test sym vs. str.
+        @model.key?(name.to_s) ? @model[name.to_s] : @model[name.to_sym]
       end
 
       def sync_hash_representer # TODO: make this without representable, please.

--- a/test/twin/struct_test.rb
+++ b/test/twin/struct_test.rb
@@ -329,3 +329,15 @@ class CompositionWithStructTest < Minitest::Spec
 
   end
 end
+
+class IndifferentAttributeAccessTwinStructTest < MiniTest::Spec
+  class Song < Disposable::Twin
+    include Property::Struct
+    property :cool?
+  end
+
+  it { Song.new(cool?: true).cool?.must_equal true }
+  it { Song.new(cool?: false).cool?.must_equal false }
+  it { Song.new('cool?' => true).cool?.must_equal true }
+  it { Song.new('cool?' => false).cool?.must_equal false }
+end


### PR DESCRIPTION
The following code has been used in the `Disposable::Twin::Property::Struct#read_value_for` to read the attribute value from the model:
`@model[name.to_s] || @model[name.to_sym]
`

If the model is a Hash with string keys and the attribute value is false the left part will be false and the result will be equal to the right part which is nil since hash keys are strings but not symbols.