### PR TITLE
Recommend Property::Struct as a replacement for Struct

### DIFF
--- a/lib/disposable/twin/struct.rb
+++ b/lib/disposable/twin/struct.rb
@@ -3,7 +3,7 @@ require "disposable/twin/property/struct"
 class Disposable::Twin
   module Struct
     def self.included(includer)
-      warn "[Disposable] The Struct module is deprecated, please use Property::Hash."
+      warn "[Disposable] The Struct module is deprecated, please use Property::Struct."
       includer.send(:include, Property::Struct)
     end
   end


### PR DESCRIPTION
The README references `include Struct`, which has since moved. If you try to use `include Struct`, this warning is triggered, recommending a replacement. But the recommended replacement is `Property::Hash`, and not `Property::Struct`. Seems like a typo.