### PR TITLE
Fixing struct when initialized with string key and when value is false

### DIFF
--- a/lib/disposable/twin/property/struct.rb
+++ b/lib/disposable/twin/property/struct.rb
@@ -6,7 +6,9 @@ class Disposable::Twin
     module Struct
       def read_value_for(dfn, options)
         name = dfn[:name]
-        @model[name.to_s] || @model[name.to_sym] # TODO: test sym vs. str.
+        # TODO: test sym vs. str.
+        return unless key_value = model.to_h.find { |k, _| k.to_sym == name.to_sym }
+        key_value.last
       end
 
       def sync_hash_representer # TODO: make this without representable, please.

--- a/test/twin/struct_test.rb
+++ b/test/twin/struct_test.rb
@@ -25,6 +25,9 @@ class TwinStructTest < MiniTest::Spec
   it { Song.new({number: 3}, {cool?: true}).cool?.must_equal true }
   it { Song.new({number: 3}, {cool?: true}).number.must_equal 3 }
 
+  # with string key and false value
+  it { Song.new('number' => 3, 'cool?' => false).cool?.must_equal false }
+
 
   describe "writing" do
     let (:song) { Song.new(model, {cool?: true}) }


### PR DESCRIPTION
There is an unexpected behaviour: when the struct is initialized with a has `'key' => false`, the resulting struct returns `nil` instead of `false`. This PR fixes this. Test included.