### PR TITLE
Fix deprecation warning for dry types from version 0.15.0.

### DIFF
--- a/lib/disposable/twin/coercion.rb
+++ b/lib/disposable/twin/coercion.rb
@@ -2,7 +2,7 @@ require "dry-types"
 
 module Disposable::Twin::Coercion
   module Types
-    include Dry::Types.module
+    include Dry.Types
   end
 
   DRY_TYPES_VERSION = Integer(Dry::Types::VERSION.split('.')[-2])


### PR DESCRIPTION
Quick fix for deprecation warning from Dry Types.  

```[dry-types] Dry::Types.module is deprecated and will be removed in the next major version
Use Dry.Types() instead. Beware, it exports strict types by default, for old behavior use Dry.Types(default: :nominal). See more options in the changelog```

[dry-types CHANGELOG](https://github.com/dry-rb/dry-types/blob/master/CHANGELOG.md#0150-2019-03-22) for reference.  