### PR TITLE
Make travis to test newer versions of dry-types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
     - rvm: ruby-head
     - env: ACTIVERECORD=4.1
     - rvm: 2.1
+    - rvm: 2.2
   exclude:
     - { rvm: 2.3, env: DRY_TYPES=1.1 }
     - { rvm: 2.2, env: DRY_TYPES=1.1 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - 2.3
   - 2.2
 env:
+  - "DRY_TYPES=1.1"
+  - "DRY_TYPES=1.0"
+  - "DRY_TYPES=0.15"
   - "DRY_TYPES=0.13"
   - "DRY_TYPES=0.12"
   - "ACTIVERECORD=5.0"
@@ -29,3 +32,10 @@ matrix:
     - rvm: ruby-head
     - env: ACTIVERECORD=4.1
     - rvm: 2.1
+  exclude:
+    - { rvm: 2.3, env: DRY_TYPES=1.1 }
+    - { rvm: 2.2, env: DRY_TYPES=1.1 }
+    - { rvm: 2.3, env: DRY_TYPES=1.0 }
+    - { rvm: 2.2, env: DRY_TYPES=1.0 }
+    - { rvm: 2.3, env: DRY_TYPES=0.15 }
+    - { rvm: 2.2, env: DRY_TYPES=0.15 }

--- a/disposable.gemspec
+++ b/disposable.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "activerecord"#, "4.2.5"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", '~> 1.3.0'
   spec.add_development_dependency "dry-types"# "~> 0.6"
   # spec.add_development_dependency "database_cleaner"
 end

--- a/disposable.gemspec
+++ b/disposable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "declarative-option",  "< 0.2.0"
   spec.add_dependency "representable", ">= 2.4.0", "<= 3.1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"#, "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "activerecord"#, "4.2.5"

--- a/lib/disposable/twin/coercion.rb
+++ b/lib/disposable/twin/coercion.rb
@@ -2,7 +2,9 @@ require "dry-types"
 
 module Disposable::Twin::Coercion
   module Types
-    include Dry::Types.module
+    # NOTE: Use Dry.Types() instead. Beware, it exports strict types by default, for old behavior use Dry.Types(default: :nominal)
+    DRY_MODULE =  Gem::Version.new(Dry::Types::VERSION) < Gem::Version.new("0.15.0") ? Dry::Types.module : Dry.Types()
+    include DRY_MODULE
   end
 
   DRY_TYPES_VERSION = Gem::Version.new(Dry::Types::VERSION)

--- a/test/twin/changed_test.rb
+++ b/test/twin/changed_test.rb
@@ -114,7 +114,7 @@ class ChangedWithCoercionTest < MiniTest::Spec
     include Changed
     include Coercion
 
-    property :released, type: DRY_TYPES_CONSTANT::Bool
+    property :released, type: DRY_TYPES_CONSTANT::Bool | DRY_TYPES_CONSTANT::Nil
   end
 
   it do

--- a/test/twin/coercion_test.rb
+++ b/test/twin/coercion_test.rb
@@ -82,7 +82,7 @@ class CoercionTest < MiniTest::Spec
              type: DRY_TYPES_CONSTANT::Date, nilify: true
     property :date_of_death_by_unicorns,
              type: DRY_TYPES_CONSTANT::Nil | DRY_TYPES_CONSTANT::Date
-    property :id, nilify: true
+    property :id, type: const_get("Types::Coercible::#{DRY_TYPES_INT_CONSTANT}"), nilify: true
   end
 
   describe "with Nilify" do
@@ -155,8 +155,7 @@ class CoercionTypingTest < MiniTest::Spec
 
     # property :title, type: Dry::Types::Strict::String.constructor(Dry::Types::Params.method(:to_nil))
 
-    constructor = Disposable::Twin::Coercion::DRY_TYPES_VERSION < Gem::Version.new("0.13.0") ? 'form.nil' : 'params.nil'
-    property :title, type: Types::Strict::String.optional.constructor(Dry::Types[constructor]) # this is the behavior of the "DB" data twin. this is NOT the form.
+    property :title, type: DRY_TYPES_CONSTANT::Nil | Types::Strict::String # this is the behavior of the "DB" data twin. this is NOT the form.
 
     # property :name, type: Types::Params::String
 

--- a/test/twin/struct/coercion_test.rb
+++ b/test/twin/struct/coercion_test.rb
@@ -10,7 +10,7 @@ class StructCoercionTest < Minitest::Spec
     feature Coercion
 
     property :content do
-      property :amount, type: DRY_TYPES_CONSTANT::Float
+      property :amount, type: DRY_TYPES_CONSTANT::Float | DRY_TYPES_CONSTANT::Nil
     end
 
     unnest :amount, from: :content


### PR DESCRIPTION
Few changes for `dry-types` 1.x where for example for `Types::Params::Nil` raise an error unless is passed either `nil` or `""` - no real changes in the gem, only test fixing