### PR TITLE
Raise an error if class is used as property name

### DIFF
--- a/lib/disposable/twin.rb
+++ b/lib/disposable/twin.rb
@@ -9,6 +9,9 @@ require "representable/decorator"
 
 module Disposable
   class Twin
+    class InvalidPropertyNameError < StandardError; end
+    INVALID_PROPERTY_NAMES = %i[class].freeze
+
     extend Declarative::Schema
     def self.definition_class
       Definition
@@ -32,6 +35,10 @@ module Disposable
 
       # TODO: move to Declarative, as in Representable and Reform.
       def property(name, options={}, &block)
+        if INVALID_PROPERTY_NAMES.include?(name)
+          raise InvalidPropertyNameError.new("#{name} is used internally and cannot be used as property name")
+        end
+
         options[:private_name] ||= options.delete(:from) || name
         is_inherited = options.delete(:_inherited)
 

--- a/test/twin/twin_test.rb
+++ b/test/twin/twin_test.rb
@@ -152,3 +152,13 @@ class AccessorsTest < Minitest::Spec
     twin.format = "blubb"
   end
 end
+
+class InvalidPropertyNameTest < Minitest::Spec
+  it 'raises InvalidPropertyNameError' do
+  assert_raises(Disposable::Twin::InvalidPropertyNameError) {
+      class Twin < Disposable::Twin
+        property :class
+      end
+    }
+  end
+end


### PR DESCRIPTION
The problem is during the initialization because using `class` as property will override the `Kernel#class` so when `self.class` is used [here](https://github.com/apotonick/disposable/blob/master/lib/disposable/twin/composition.rb#L19) will return `nil`.

This PR should "resolve" this https://github.com/trailblazer/reform/issues/471 - more than resolve we simply notify the User that `class` cannot be used