### PR TITLE
Deprecate nilify for new versions of dry-types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test/tmp
 test/version_tmp
 tmp
 Gemfile*.lock
+.rubocop*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,44 @@
 language: ruby
-sudo: false
 rvm:
   - ruby-head
+  - 2.6
   - 2.5
   - 2.4
-  - 2.3
-  - 2.2
 env:
-  - "DRY_TYPES=1.1"
-  - "DRY_TYPES=1.0"
-  - "DRY_TYPES=0.15"
-  - "DRY_TYPES=0.13"
-  - "DRY_TYPES=0.12"
-  - "ACTIVERECORD=5.0"
-  - "ACTIVERECORD=5.1"
-  - "ACTIVERECORD=5.2"
+  - "ACTIVERECORD=5.0 DRY_TYPES=0.13"
+  - "ACTIVERECORD=5.0 DRY_TYPES=0.14"
+  - "ACTIVERECORD=5.0 DRY_TYPES=0.15"
+  - "ACTIVERECORD=5.0 DRY_TYPES=1.0"
+  - "ACTIVERECORD=5.0 DRY_TYPES=1.1"
+  - "ACTIVERECORD=5.0 DRY_TYPES=1.2"
+  - "ACTIVERECORD=5.1 DRY_TYPES=0.13"
+  - "ACTIVERECORD=5.1 DRY_TYPES=0.14"
+  - "ACTIVERECORD=5.1 DRY_TYPES=0.15"
+  - "ACTIVERECORD=5.1 DRY_TYPES=1.0"
+  - "ACTIVERECORD=5.1 DRY_TYPES=1.1"
+  - "ACTIVERECORD=5.1 DRY_TYPES=1.2"
+  - "ACTIVERECORD=5.2 DRY_TYPES=0.13"
+  - "ACTIVERECORD=5.2 DRY_TYPES=0.14"
+  - "ACTIVERECORD=5.2 DRY_TYPES=0.15"
+  - "ACTIVERECORD=5.2 DRY_TYPES=1.0"
+  - "ACTIVERECORD=5.2 DRY_TYPES=1.1"
+  - "ACTIVERECORD=5.2 DRY_TYPES=1.2"
+  - "ACTIVERECORD=6.0 DRY_TYPES=0.13"
+  - "ACTIVERECORD=6.0 DRY_TYPES=0.14"
+  - "ACTIVERECORD=6.0 DRY_TYPES=0.15"
+  - "ACTIVERECORD=6.0 DRY_TYPES=1.0"
+  - "ACTIVERECORD=6.0 DRY_TYPES=1.1"
+  - "ACTIVERECORD=6.0 DRY_TYPES=1.2"
 gemfile:
   - Gemfile
 matrix:
   fast_finish: true
-  include:
-    - { rvm: 2.3, env: ACTIVERECORD=4.2  }
-    - { rvm: 2.2, env: ACTIVERECORD=4.2  }
-    - { rvm: 2.3, env: ACTIVERECORD=4.1  }
-    - { rvm: 2.2, env: ACTIVERECORD=4.1  }
-    - rvm: 2.1
-      env:
-        - ACTIVERECORD=4.1
-        - DRY_TYPES=0.10
   allow_failures:
     - rvm: ruby-head
-    - env: ACTIVERECORD=4.1
-    - rvm: 2.1
-    - rvm: 2.2
   exclude:
-    - { rvm: 2.3, env: DRY_TYPES=1.1 }
-    - { rvm: 2.2, env: DRY_TYPES=1.1 }
-    - { rvm: 2.3, env: DRY_TYPES=1.0 }
-    - { rvm: 2.2, env: DRY_TYPES=1.0 }
-    - { rvm: 2.3, env: DRY_TYPES=0.15 }
-    - { rvm: 2.2, env: DRY_TYPES=0.15 }
+    - {rvm: 2.4, env: "ACTIVERECORD=6.0 DRY_TYPES=0.13"}
+    - {rvm: 2.4, env: "ACTIVERECORD=6.0 DRY_TYPES=0.14"}
+    - {rvm: 2.4, env: "ACTIVERECORD=6.0 DRY_TYPES=0.15"}
+    - {rvm: 2.4, env: "ACTIVERECORD=6.0 DRY_TYPES=1.0"}
+    - {rvm: 2.4, env: "ACTIVERECORD=6.0 DRY_TYPES=1.1"}
+    - {rvm: 2.4, env: "ACTIVERECORD=6.0 DRY_TYPES=1.2"}

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gem "minitest-line"
   gem gem_name, dependency
 end
 
-
+gem "sqlite3", ENV.fetch('ACTIVERECORD', '5.2').to_f >= 6 ? '~> 1.4' : '~> 1.3.0'

--- a/disposable.gemspec
+++ b/disposable.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "activerecord"#, "4.2.5"
-  spec.add_development_dependency "sqlite3", '~> 1.3.0'
   spec.add_development_dependency "dry-types"# "~> 0.6"
   # spec.add_development_dependency "database_cleaner"
 end

--- a/lib/disposable/twin/coercion.rb
+++ b/lib/disposable/twin/coercion.rb
@@ -18,7 +18,10 @@ module Disposable::Twin::Coercion
     end
 
     def coercing_setter!(name, type, nilify=false)
-     type = type ? (DRY_TYPES_CONSTANT::Nil | type) : DRY_TYPES_CONSTANT::Nil if nilify
+      # TODO: remove nilily with next release (0.5) for new dry-type versions
+      type = type ? (DRY_TYPES_CONSTANT::Nil | type) : DRY_TYPES_CONSTANT::Nil if nilify
+
+      warn "DEPRECATION WARNING [Disposable]: nilify is deprecated and it will be removed with the next release" if nilify && DRY_TYPES_CONSTANT == Types::Params
 
       mod = Module.new do
         define_method("#{name}=") do |value|

--- a/lib/disposable/twin/coercion.rb
+++ b/lib/disposable/twin/coercion.rb
@@ -21,7 +21,7 @@ module Disposable::Twin::Coercion
       # TODO: remove nilily with next release (0.5) for new dry-type versions
       type = type ? (DRY_TYPES_CONSTANT::Nil | type) : DRY_TYPES_CONSTANT::Nil if nilify
 
-      warn "DEPRECATION WARNING [Disposable]: nilify is deprecated and it will be removed with the next release" if nilify && DRY_TYPES_CONSTANT == Types::Params
+      warn "DEPRECATION WARNING [Disposable]: nilify is deprecated and it will be removed with the next release" if nilify && DRY_TYPES_VERSION >= Gem::Version.new("1.0.0")
 
       mod = Module.new do
         define_method("#{name}=") do |value|

--- a/test/callback_group_test.rb
+++ b/test/callback_group_test.rb
@@ -55,7 +55,7 @@ class CallbackGroupTest < MiniTest::Spec
     album = Album.new(songs: [Song.new(title: "Dead To Me"), Song.new(title: "Diesel Boy")])
     twin  = AlbumTwin.new(album)
 
-    Group.new(twin).().invocations.must_equal [
+    expect(Group.new(twin).().invocations).must_equal [
       [:on_change, :change!, []],
       [:on_add, :notify_album!, []],
       [:on_add, :reset_song!, []],
@@ -76,7 +76,7 @@ class CallbackGroupTest < MiniTest::Spec
 
     group = Group.new(twin).(content: content)
 
-    group.invocations.must_equal [
+    expect(group.invocations).must_equal [
       [:on_change, :change!, [twin]],
       [:on_add, :notify_album!, [twin.songs[0], twin.songs[1]]],
       [:on_add, :reset_song!,   [twin.songs[0], twin.songs[1]]],
@@ -85,8 +85,8 @@ class CallbackGroupTest < MiniTest::Spec
       [:on_update, :expire_cache!, []],
     ]
 
-    content.must_equal "notify_album!notify_album!reset_song!reset_song!"
-    group.output.must_equal "Album has changed!"
+    expect(content).must_equal "notify_album!notify_album!reset_song!reset_song!"
+    expect(group.output).must_equal "Album has changed!"
   end
 
 
@@ -129,7 +129,7 @@ class CallbackGroupTest < MiniTest::Spec
 
     # pp group.invocations
 
-    group.invocations.must_equal [
+    expect(group.invocations).must_equal [
       [:on_change, :change!, [twin]],
       [:on_add, :notify_album!, [twin.songs[0]]],
       [:on_add, :reset_song!,   [twin.songs[0]]],
@@ -138,7 +138,7 @@ class CallbackGroupTest < MiniTest::Spec
       [:on_update, :expire_cache!, []],
     ]
 
-    content.must_equal "Op: changed! [CallbackGroupTest::Operation]Op: notify_album! [CallbackGroupTest::Operation]Op: reset_song! [CallbackGroupTest::Operation]"
+    expect(content).must_equal "Op: changed! [CallbackGroupTest::Operation]Op: notify_album! [CallbackGroupTest::Operation]Op: reset_song! [CallbackGroupTest::Operation]"
   end
 end
 
@@ -157,12 +157,12 @@ class CallbackGroupInheritanceTest < MiniTest::Spec
   end
 
   it do
-    Group.hooks.size.must_equal 4
-    Group.hooks[0].to_s.must_equal "[:on_change, :change!, {}]"
+    expect(Group.hooks.size).must_equal 4
+    expect(Group.hooks[0].to_s).must_equal "[:on_change, :change!, {}]"
     # Group.hooks[1][1][:nested].hooks.to_s.must_equal "[[:on_add, [:notify_album!]],[:on_add, [:reset_song!]]]"
-    Group.hooks[2].to_s.must_equal "[:on_change, :rehash_name!, {:property=>:title}]"
+    expect(Group.hooks[2].to_s).must_equal "[:on_change, :rehash_name!, {:property=>:title}]"
 
-    Group.definitions.get(Group.hooks[3][1])[:nested].hooks.to_s.must_equal "[[:on_change, :sing!, {}]]"
+    expect(Group.definitions.get(Group.hooks[3][1])[:nested].hooks.to_s).must_equal "[[:on_change, :sing!, {}]]"
   end
 
   class EmptyGroup < Group
@@ -171,7 +171,7 @@ class CallbackGroupInheritanceTest < MiniTest::Spec
 
 
   it do
-    EmptyGroup.hooks.size.must_equal 4
+    expect(EmptyGroup.hooks.size).must_equal 4
     # TODO:
   end
 
@@ -183,10 +183,10 @@ class CallbackGroupInheritanceTest < MiniTest::Spec
   end
 
   it do
-    Group.hooks.size.must_equal 4
+    expect(Group.hooks.size).must_equal 4
     # pp EnhancedGroup.hooks
-    EnhancedGroup.hooks.size.must_equal 6
-    EnhancedGroup.definitions.get(EnhancedGroup.hooks[5][1])[:nested].hooks.to_s.must_equal "[[:on_add, :rewind!, {}]]"
+    expect(EnhancedGroup.hooks.size).must_equal 6
+    expect(EnhancedGroup.definitions.get(EnhancedGroup.hooks[5][1])[:nested].hooks.to_s).must_equal "[[:on_add, :rewind!, {}]]"
   end
 
   class EnhancedWithInheritGroup < EnhancedGroup
@@ -199,13 +199,13 @@ class CallbackGroupInheritanceTest < MiniTest::Spec
   end
 
   it do
-    Group.hooks.size.must_equal 4
-    EnhancedGroup.hooks.size.must_equal 6
+    expect(Group.hooks.size).must_equal 4
+    expect(EnhancedGroup.hooks.size).must_equal 6
 
-    EnhancedGroup.definitions.get(EnhancedGroup.hooks[5][1])[:nested].hooks.to_s.must_equal "[[:on_add, :rewind!, {}]]"
-    EnhancedWithInheritGroup.hooks.size.must_equal 6
-    EnhancedWithInheritGroup.definitions.get(EnhancedWithInheritGroup.hooks[1][1])[:nested].hooks.to_s.must_equal "[[:on_add, :rewind!, {}], [:on_add, :eat!, {}]]"
-    EnhancedWithInheritGroup.definitions.get(EnhancedWithInheritGroup.hooks[3][1])[:nested].hooks.to_s.must_equal "[[:on_change, :sing!, {}], [:on_delete, :yell!, {}]]"
+    expect(EnhancedGroup.definitions.get(EnhancedGroup.hooks[5][1])[:nested].hooks.to_s).must_equal "[[:on_add, :rewind!, {}]]"
+    expect(EnhancedWithInheritGroup.hooks.size).must_equal 6
+    expect(EnhancedWithInheritGroup.definitions.get(EnhancedWithInheritGroup.hooks[1][1])[:nested].hooks.to_s).must_equal "[[:on_add, :rewind!, {}], [:on_add, :eat!, {}]]"
+    expect(EnhancedWithInheritGroup.definitions.get(EnhancedWithInheritGroup.hooks[3][1])[:nested].hooks.to_s).must_equal "[[:on_change, :sing!, {}], [:on_delete, :yell!, {}]]"
   end
 
   class RemovingInheritGroup < Group
@@ -226,10 +226,10 @@ class CallbackGroupInheritanceTest < MiniTest::Spec
   # TODO: object_id tests for all nested representers.
 
   it do
-    Group.hooks.size.must_equal 4
-    RemovingInheritGroup.hooks.size.must_equal 3
-    RemovingInheritGroup.definitions.get(RemovingInheritGroup.hooks[0][1])[:nested].hooks.to_s.must_equal "[[:on_add, :reset_song!, {}]]"
-    RemovingInheritGroup.definitions.get(RemovingInheritGroup.hooks[2][1])[:nested].hooks.to_s.must_equal "[[:on_change, :sing!, {}]]"
+    expect(Group.hooks.size).must_equal 4
+    expect(RemovingInheritGroup.hooks.size).must_equal 3
+    expect(RemovingInheritGroup.definitions.get(RemovingInheritGroup.hooks[0][1])[:nested].hooks.to_s).must_equal "[[:on_add, :reset_song!, {}]]"
+    expect(RemovingInheritGroup.definitions.get(RemovingInheritGroup.hooks[2][1])[:nested].hooks.to_s).must_equal "[[:on_change, :sing!, {}]]"
   end
 
   # Group::clone
@@ -239,7 +239,7 @@ class CallbackGroupInheritanceTest < MiniTest::Spec
   end
 
   it do
-    Group.hooks.size.must_equal 4
-    ClonedGroup.hooks.size.must_equal 3
+    expect(Group.hooks.size).must_equal 4
+    expect(ClonedGroup.hooks.size).must_equal 3
   end
 end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -46,7 +46,7 @@ class CallbacksTest < MiniTest::Spec
     it do
       invokes = []
       Callback.new(twin).on_create { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # save, without any attributes changed.
@@ -55,7 +55,7 @@ class CallbacksTest < MiniTest::Spec
 
       invokes = []
       Callback.new(twin).on_create { |t| invokes << t }
-      invokes.must_equal [twin]
+      expect(invokes).must_equal [twin]
     end
 
     # before and after save, with attributes changed
@@ -64,12 +64,12 @@ class CallbacksTest < MiniTest::Spec
       twin.name = "Run For Cover"
       invokes = []
       Callback.new(twin).on_create { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       twin.save
 
       Callback.new(twin).on_create { |t| invokes << t }
-      invokes.must_equal [twin]
+      expect(invokes).must_equal [twin]
     end
 
     # for collections.
@@ -80,12 +80,12 @@ class CallbacksTest < MiniTest::Spec
       invokes = []
 
       Callback.new(twin.songs).on_create { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       twin.save
 
       Callback.new(twin.songs).on_create { |t| invokes << t }
-      invokes.must_equal [twin.songs[0], twin.songs[2]]
+      expect(invokes).must_equal [twin.songs[0], twin.songs[2]]
     end
   end
 
@@ -96,7 +96,7 @@ class CallbacksTest < MiniTest::Spec
     it do
       invokes = []
       Callback.new(twin).on_update { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # single twin.
@@ -106,40 +106,40 @@ class CallbacksTest < MiniTest::Spec
 
       invokes = []
       Callback.new(twin).on_update { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       invokes = []
       twin.save
 
       Callback.new(twin).on_update { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
 
       # now with the persisted album.
       twin = AlbumTwin.new(album) # Album is persisted now.
 
       Callback.new(twin).on_update { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       invokes = []
       twin.save
 
       # nothing has changed, yet.
       Callback.new(twin).on_update { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       twin.name= "Corridors Of Power"
 
       # this will even trigger on_update before saving.
       Callback.new(twin).on_update { |t| invokes << t }
-      invokes.must_equal [twin]
+      expect(invokes).must_equal [twin]
 
       invokes = []
       twin.save
 
       # name changed.
       Callback.new(twin).on_update { |t| invokes << t }
-      invokes.must_equal [twin]
+      expect(invokes).must_equal [twin]
     end
 
     # for collections.
@@ -150,41 +150,41 @@ class CallbacksTest < MiniTest::Spec
 
       invokes = []
       Callback.new(twin.songs).on_update { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       invokes = []
       twin.save
 
       # initial save is no update.
       Callback.new(twin.songs).on_update { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
 
       # now with the persisted album.
       twin = AlbumTwin.new(album) # Album is persisted now.
 
       Callback.new(twin.songs).on_update { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       invokes = []
       twin.save
 
       # nothing has changed, yet.
       Callback.new(twin.songs).on_update { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       twin.songs[1].title= "After The War"
       twin.songs[2].title= "Run For Cover"
 
       # # this will even trigger on_update before saving.
       Callback.new(twin.songs).on_update { |t| invokes << t }
-      invokes.must_equal [twin.songs[1], twin.songs[2]]
+      expect(invokes).must_equal [twin.songs[1], twin.songs[2]]
 
       invokes = []
       twin.save
 
       Callback.new(twin.songs).on_update { |t| invokes << t }
-      invokes.must_equal [twin.songs[1], twin.songs[2]]
+      expect(invokes).must_equal [twin.songs[1], twin.songs[2]]
     end
     # it do
     #   album.songs << song1 = Song.new
@@ -210,7 +210,7 @@ class CallbacksTest < MiniTest::Spec
     it do
       invokes = []
       Callback.new(twin.songs).on_add { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # collection present on initialize are not added.
@@ -220,7 +220,7 @@ class CallbacksTest < MiniTest::Spec
       album.songs = [ex_song, song]
 
       Callback.new(twin.songs).on_add { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # items added after initialization are added.
@@ -232,14 +232,14 @@ class CallbacksTest < MiniTest::Spec
       twin.songs << song
 
       Callback.new(twin.songs).on_add { |t| invokes << t }
-      invokes.must_equal [twin.songs[1]]
+      expect(invokes).must_equal [twin.songs[1]]
 
       twin.save
 
       # still shows the added after save.
       invokes = []
       Callback.new(twin.songs).on_add { |t| invokes << t }
-      invokes.must_equal [twin.songs[1]]
+      expect(invokes).must_equal [twin.songs[1]]
     end
   end
 
@@ -250,7 +250,7 @@ class CallbacksTest < MiniTest::Spec
     it do
       invokes = []
       Callback.new(twin.songs).on_add(:created) { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # collection present on initialize are not added.
@@ -260,7 +260,7 @@ class CallbacksTest < MiniTest::Spec
       album.songs = [ex_song, song]
 
       Callback.new(twin.songs).on_add(:created) { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # items added after initialization are added.
@@ -273,14 +273,14 @@ class CallbacksTest < MiniTest::Spec
       twin.songs << ex_song # already created.
 
       Callback.new(twin.songs).on_add(:created) { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       twin.save
 
       # still shows the added after save.
       invokes = []
       Callback.new(twin.songs).on_add(:created) { |t| invokes << t }
-      invokes.must_equal [twin.songs[1]] # only the created is invoked.
+      expect(invokes).must_equal [twin.songs[1]] # only the created is invoked.
     end
   end
 
@@ -291,7 +291,7 @@ class CallbacksTest < MiniTest::Spec
     it do
       invokes = []
       Callback.new(twin.songs).on_delete { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # collection present but nothing deleted.
@@ -301,7 +301,7 @@ class CallbacksTest < MiniTest::Spec
       album.songs = [ex_song, song]
 
       Callback.new(twin.songs).on_delete { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # items deleted.
@@ -313,14 +313,14 @@ class CallbacksTest < MiniTest::Spec
       twin.songs.delete(deleted = twin.songs[0])
 
       Callback.new(twin.songs).on_delete { |t| invokes << t }
-      invokes.must_equal [deleted]
+      expect(invokes).must_equal [deleted]
 
       twin.save
 
       # still shows the deleted after save.
       invokes = []
       Callback.new(twin.songs).on_delete { |t| invokes << t }
-      invokes.must_equal [deleted]
+      expect(invokes).must_equal [deleted]
     end
   end
 
@@ -331,7 +331,7 @@ class CallbacksTest < MiniTest::Spec
     it do
       invokes = []
       Callback.new(twin.songs).on_destroy { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # collection present but nothing deleted.
@@ -341,7 +341,7 @@ class CallbacksTest < MiniTest::Spec
       album.songs = [ex_song, song]
 
       Callback.new(twin.songs).on_destroy { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # items deleted, doesn't trigger on_destroy.
@@ -353,7 +353,7 @@ class CallbacksTest < MiniTest::Spec
       twin.songs.delete(twin.songs[0])
 
       Callback.new(twin.songs).on_destroy { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # items destroyed.
@@ -365,7 +365,7 @@ class CallbacksTest < MiniTest::Spec
       twin.songs.destroy(deleted = twin.songs[0])
 
       Callback.new(twin.songs).on_destroy { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       twin.extend(Disposable::Twin::Collection::Semantics) # now #save will destroy.
       twin.save
@@ -373,7 +373,7 @@ class CallbacksTest < MiniTest::Spec
       # still shows the deleted after save.
       invokes = []
       Callback.new(twin.songs).on_destroy { |t| invokes << t }
-      invokes.must_equal [deleted]
+      expect(invokes).must_equal [deleted]
     end
   end
 
@@ -384,7 +384,7 @@ class CallbacksTest < MiniTest::Spec
     # after initialization
     it do
       Callback.new(twin).on_change { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
     end
 
     # save, without any attributes changed. unpersisted before.
@@ -394,7 +394,7 @@ class CallbacksTest < MiniTest::Spec
       twin.save
 
       Callback.new(twin).on_change { |t| invokes << t }
-      invokes.must_equal [] # nothing has changed, not even persisted?.
+      expect(invokes).must_equal [] # nothing has changed, not even persisted?.
     end
 
     # save, without any attributes changed. persisted before.
@@ -402,7 +402,7 @@ class CallbacksTest < MiniTest::Spec
       twin.save
 
       Callback.new(twin).on_change { |t| invokes << t }
-      invokes.must_equal [twin]
+      expect(invokes).must_equal [twin]
     end
 
     # before and after save, with attributes changed
@@ -411,24 +411,24 @@ class CallbacksTest < MiniTest::Spec
       twin.name = "Run For Cover"
       invokes = []
       Callback.new(twin).on_change { |t| invokes << t }
-      invokes.must_equal [twin]
+      expect(invokes).must_equal [twin]
 
       twin.save
 
       invokes = []
       Callback.new(twin).on_change { |t| invokes << t }
-      invokes.must_equal [twin]
+      expect(invokes).must_equal [twin]
     end
 
     # for scalars: on_change(:email).
     it do
       Callback.new(twin).on_change(property: :name) { |t| invokes << t }
-      invokes.must_equal []
+      expect(invokes).must_equal []
 
       twin.name = "Unforgiven"
 
       Callback.new(twin).on_change(property: :name) { |t| invokes << t }
-      invokes.must_equal [twin]
+      expect(invokes).must_equal [twin]
     end
 
     # for collections.

--- a/test/expose_test.rb
+++ b/test/expose_test.rb
@@ -24,8 +24,8 @@ class ExposeTest < MiniTest::Spec
 
   describe "readers" do
     it  do
-      subject.id.must_equal 1
-      subject.title.must_equal "Dick Sandwich"
+      expect(subject.id).must_equal 1
+      expect(subject.title).must_equal "Dick Sandwich"
     end
   end
 
@@ -35,10 +35,10 @@ class ExposeTest < MiniTest::Spec
       subject.id = 3
       subject.title = "Eclipse"
 
-      subject.id.must_equal 3
-      subject.title.must_equal "Eclipse"
-      album.id.must_equal 3
-      album.name.must_equal "Eclipse"
+      expect(subject.id).must_equal 3
+      expect(subject.title).must_equal "Eclipse"
+      expect(album.id).must_equal 3
+      expect(album.name).must_equal "Eclipse"
     end
   end
 end
@@ -69,9 +69,9 @@ class ExposeCompositionTest < MiniTest::Spec
 
 
   describe "readers" do
-    it { subject.id.must_equal 2 }
-    it { subject.band_id.must_equal 1 }
-    it { subject.name.must_equal "Dick Sandwich" }
+    it { expect(subject.id).must_equal 2 }
+    it { expect(subject.band_id).must_equal 1 }
+    it { expect(subject.name).must_equal "Dick Sandwich" }
   end
 
 
@@ -81,12 +81,12 @@ class ExposeCompositionTest < MiniTest::Spec
       subject.band_id = 4
       subject.name = "Eclipse"
 
-      subject.id.must_equal 3
-      subject.band_id.must_equal 4
-      subject.name.must_equal "Eclipse"
-      band.id.must_equal 4
-      album.id.must_equal 3
-      album.name.must_equal "Eclipse"
+      expect(subject.id).must_equal 3
+      expect(subject.band_id).must_equal 4
+      expect(subject.name).must_equal "Eclipse"
+      expect(band.id).must_equal 4
+      expect(album.id).must_equal 3
+      expect(album.name).must_equal "Eclipse"
     end
   end
 end

--- a/test/persisted_test.rb
+++ b/test/persisted_test.rb
@@ -29,36 +29,36 @@ class PersistedTest < MiniTest::Spec
     album   = Album.new(artist: artist, songs: [ex_song, song])
 
 
-    artist.persisted?.must_equal false
-    album.persisted?.must_equal false
-    ex_song.persisted?.must_equal true
-    song.persisted?.must_equal false
+    expect(artist.persisted?).must_equal false
+    expect(album.persisted?).must_equal false
+    expect(ex_song.persisted?).must_equal true
+    expect(song.persisted?).must_equal false
 
     twin = AlbumTwin.new(album)
-    twin.persisted?.must_equal false
-    twin.changed?(:persisted?).must_equal false
-    twin.artist.persisted?.must_equal false
-    twin.artist.changed?(:persisted?).must_equal false
-    twin.songs[0].persisted?.must_equal true
-    twin.songs[0].changed?(:persisted?).must_equal false
-    twin.songs[1].persisted?.must_equal false
-    twin.songs[1].changed?(:persisted?).must_equal false
+    expect(twin.persisted?).must_equal false
+    expect(twin.changed?(:persisted?)).must_equal false
+    expect(twin.artist.persisted?).must_equal false
+    expect(twin.artist.changed?(:persisted?)).must_equal false
+    expect(twin.songs[0].persisted?).must_equal true
+    expect(twin.songs[0].changed?(:persisted?)).must_equal false
+    expect(twin.songs[1].persisted?).must_equal false
+    expect(twin.songs[1].changed?(:persisted?)).must_equal false
 
     twin.save
 
-    artist.persisted?.must_equal true
-    album.persisted?.must_equal true
-    ex_song.persisted?.must_equal true
-    song.persisted?.must_equal true
+    expect(artist.persisted?).must_equal true
+    expect(album.persisted?).must_equal true
+    expect(ex_song.persisted?).must_equal true
+    expect(song.persisted?).must_equal true
 
-    twin.persisted?.must_equal true
-    twin.changed?(:persisted?).must_equal true
-    twin.artist.persisted?.must_equal true
-    twin.artist.changed?(:persisted?).must_equal true
-    twin.songs[0].persisted?.must_equal true
-    twin.songs[0].changed?(:persisted?).must_equal false
-    twin.songs[1].persisted?.must_equal true
-    twin.songs[1].changed?(:persisted?).must_equal true
+    expect(twin.persisted?).must_equal true
+    expect(twin.changed?(:persisted?)).must_equal true
+    expect(twin.artist.persisted?).must_equal true
+    expect(twin.artist.changed?(:persisted?)).must_equal true
+    expect(twin.songs[0].persisted?).must_equal true
+    expect(twin.songs[0].changed?(:persisted?)).must_equal false
+    expect(twin.songs[1].persisted?).must_equal true
+    expect(twin.songs[1].changed?(:persisted?)).must_equal true
   end
 
 
@@ -66,17 +66,17 @@ class PersistedTest < MiniTest::Spec
     it do
       twin = AlbumTwin.new(Album.new)
 
-      twin.created?.must_equal false
+      expect(twin.created?).must_equal false
       twin.save
-      twin.created?.must_equal true
+      expect(twin.created?).must_equal true
     end
 
     it do
       twin = AlbumTwin.new(Album.create)
 
-      twin.created?.must_equal false
+      expect(twin.created?).must_equal false
       twin.save
-      twin.created?.must_equal false
+      expect(twin.created?).must_equal false
     end
   end
 

--- a/test/rescheme_test.rb
+++ b/test/rescheme_test.rb
@@ -37,22 +37,22 @@ class ReschemeTest < MiniTest::Spec
     )
 
     # include: works.
-    decorator.new(nil).hello.must_equal "hello"
-    decorator.new(nil).ciao.must_equal "ciao"
+    expect(decorator.new(nil).hello).must_equal "hello"
+    expect(decorator.new(nil).ciao).must_equal "ciao"
 
-    decorator.representable_attrs.get(:id).inspect.must_equal "#<Representable::Definition ==>id @options={:name=>\"id\", :parse_filter=>[], :render_filter=>[]}>"
-    decorator.representable_attrs.get(:title).inspect.must_equal "#<Representable::Definition ==>title @options={:writeable=>false, :deserializer=>{:skip_parse=>\"skip lambda\"}, :name=>\"title\", :parse_filter=>[], :render_filter=>[], :skip_parse=>\"skip lambda\"}>"
+    expect(decorator.representable_attrs.get(:id).inspect).must_equal "#<Representable::Definition ==>id @options={:name=>\"id\", :parse_filter=>[], :render_filter=>[]}>"
+    expect(decorator.representable_attrs.get(:title).inspect).must_equal "#<Representable::Definition ==>title @options={:writeable=>false, :deserializer=>{:skip_parse=>\"skip lambda\"}, :name=>\"title\", :parse_filter=>[], :render_filter=>[], :skip_parse=>\"skip lambda\"}>"
 
     songs = decorator.representable_attrs.get(:songs)
     options = songs.instance_variable_get(:@options)
     options[:nested].extend(Declarative::Inspect)
-    options.inspect.must_equal "{:readable=>false, :deserializer=>{:skip_parse=>\"another lambda\", :music=>true, :writeable=>false}, :nested=>#<Class:>, :extend=>#<Class:>, :name=>\"songs\", :parse_filter=>[], :render_filter=>[], :skip_parse=>\"another lambda\", :music=>true, :writeable=>false}"
+    expect(options.inspect).must_equal "{:readable=>false, :deserializer=>{:skip_parse=>\"another lambda\", :music=>true, :writeable=>false}, :nested=>#<Class:>, :extend=>#<Class:>, :name=>\"songs\", :parse_filter=>[], :render_filter=>[], :skip_parse=>\"another lambda\", :music=>true, :writeable=>false}"
 
     # nested works.
-    options[:nested].new(nil).hello.must_equal "hello"
-    options[:nested].new(nil).ciao.must_equal "ciao"
+    expect(options[:nested].new(nil).hello).must_equal "hello"
+    expect(options[:nested].new(nil).ciao).must_equal "ciao"
 
-    options[:nested].representable_attrs.get(:name).inspect.must_equal "#<Representable::Definition ==>name @options={:as=>\"Name\", :deserializer=>{:skip_parse=>\"a crazy cool instance method\"}, :name=>\"name\", :parse_filter=>[], :render_filter=>[], :skip_parse=>\"a crazy cool instance method\"}>"
+    expect(options[:nested].representable_attrs.get(:name).inspect).must_equal "#<Representable::Definition ==>name @options={:as=>\"Name\", :deserializer=>{:skip_parse=>\"a crazy cool instance method\"}, :name=>\"name\", :parse_filter=>[], :render_filter=>[], :skip_parse=>\"a crazy cool instance method\"}>"
   end
 
   # :options_from and :include is optional
@@ -61,8 +61,8 @@ class ReschemeTest < MiniTest::Spec
       definitions_from: lambda { |nested| nested.definitions }
     )
 
-    decorator.representable_attrs.get(:id).inspect.must_equal "#<Representable::Definition ==>id @options={:name=>\"id\", :parse_filter=>[], :render_filter=>[]}>"
-    decorator.representable_attrs.get(:title).inspect.must_equal "#<Representable::Definition ==>title @options={:writeable=>false, :deserializer=>{:skip_parse=>\"skip lambda\"}, :name=>\"title\", :parse_filter=>[], :render_filter=>[]}>"
+    expect(decorator.representable_attrs.get(:id).inspect).must_equal "#<Representable::Definition ==>id @options={:name=>\"id\", :parse_filter=>[], :render_filter=>[]}>"
+    expect(decorator.representable_attrs.get(:title).inspect).must_equal "#<Representable::Definition ==>title @options={:writeable=>false, :deserializer=>{:skip_parse=>\"skip lambda\"}, :name=>\"title\", :parse_filter=>[], :render_filter=>[]}>"
   end
 
 
@@ -73,9 +73,9 @@ class ReschemeTest < MiniTest::Spec
       exclude_options: [:deserializer]
     )
 
-    decorator.representable_attrs.get(:id).inspect.must_equal "#<Representable::Definition ==>id @options={:name=>\"id\", :parse_filter=>[], :render_filter=>[]}>"
-    decorator.representable_attrs.get(:title).inspect.must_equal "#<Representable::Definition ==>title @options={:writeable=>false, :name=>\"title\", :parse_filter=>[], :render_filter=>[]}>"
-    decorator.representable_attrs.get(:songs).representer_module.representable_attrs.get(:name).inspect.must_equal "#<Representable::Definition ==>name @options={:as=>\"Name\", :name=>\"name\", :parse_filter=>[], :render_filter=>[]}>"
+    expect(decorator.representable_attrs.get(:id).inspect).must_equal "#<Representable::Definition ==>id @options={:name=>\"id\", :parse_filter=>[], :render_filter=>[]}>"
+    expect(decorator.representable_attrs.get(:title).inspect).must_equal "#<Representable::Definition ==>title @options={:writeable=>false, :name=>\"title\", :parse_filter=>[], :render_filter=>[]}>"
+    expect(decorator.representable_attrs.get(:songs).representer_module.representable_attrs.get(:name).inspect).must_equal "#<Representable::Definition ==>name @options={:as=>\"Name\", :name=>\"name\", :parse_filter=>[], :render_filter=>[]}>"
   end
 
 
@@ -85,8 +85,8 @@ class ReschemeTest < MiniTest::Spec
       definitions_from: lambda { |nested| nested.definitions },
     ) { |dfn| dfn.merge!(amazing: true) }
 
-    decorator.representable_attrs.get(:id).inspect.must_equal "#<Representable::Definition ==>id @options={:name=>\"id\", :parse_filter=>[], :render_filter=>[], :amazing=>true}>"
-    decorator.representable_attrs.get(:songs).representer_module.representable_attrs.get(:name).inspect.must_equal "#<Representable::Definition ==>name @options={:as=>\"Name\", :deserializer=>{:skip_parse=>\"a crazy cool instance method\"}, :name=>\"name\", :parse_filter=>[], :render_filter=>[], :amazing=>true}>"
+    expect(decorator.representable_attrs.get(:id).inspect).must_equal "#<Representable::Definition ==>id @options={:name=>\"id\", :parse_filter=>[], :render_filter=>[], :amazing=>true}>"
+    expect(decorator.representable_attrs.get(:songs).representer_module.representable_attrs.get(:name).inspect).must_equal "#<Representable::Definition ==>name @options={:as=>\"Name\", :deserializer=>{:skip_parse=>\"a crazy cool instance method\"}, :name=>\"name\", :parse_filter=>[], :render_filter=>[], :amazing=>true}>"
   end
 
   it "recursive: false only copies first level" do
@@ -97,8 +97,8 @@ class ReschemeTest < MiniTest::Spec
       exclude_options: [:deserializer]
     )
 
-    decorator.representable_attrs.get(:title).inspect.must_equal "#<Representable::Definition ==>title @options={:writeable=>false, :name=>\"title\", :parse_filter=>[], :render_filter=>[]}>"
-    decorator.representable_attrs.get(:songs).representer_module.representable_attrs.get(:name).inspect.must_equal "#<Representable::Definition ==>name @options={:as=>\"Name\", :deserializer=>{:skip_parse=>\"a crazy cool instance method\"}, :name=>\"name\", :parse_filter=>[], :render_filter=>[]}>"
+    expect(decorator.representable_attrs.get(:title).inspect).must_equal "#<Representable::Definition ==>title @options={:writeable=>false, :name=>\"title\", :parse_filter=>[], :render_filter=>[]}>"
+    expect(decorator.representable_attrs.get(:songs).representer_module.representable_attrs.get(:name).inspect).must_equal "#<Representable::Definition ==>name @options={:as=>\"Name\", :deserializer=>{:skip_parse=>\"a crazy cool instance method\"}, :name=>\"name\", :parse_filter=>[], :render_filter=>[]}>"
   end
 
   describe ":exclude_properties" do
@@ -121,8 +121,8 @@ class ReschemeTest < MiniTest::Spec
         exclude_properties: [:id]
       )
 
-      decorator.definitions.keys.must_equal ["songs"]
-      decorator.definitions.get(:songs).representer_module.definitions.keys.must_equal ["name"]
+      expect(decorator.definitions.keys).must_equal ["songs"]
+      expect(decorator.definitions.get(:songs).representer_module.definitions.keys).must_equal ["name"]
     end
   end
 end
@@ -145,8 +145,8 @@ class TwinReschemeTest < MiniTest::Spec
     artist = decorator.representable_attrs.get(:artist)
     options = artist.instance_variable_get(:@options)
     nested_extend = options[:nested]
-    options.extend(Declarative::Inspect).inspect.must_equal "{:private_name=>:artist, :nested=>#<Class:>, :name=>\"artist\", :extend=>#<Class:>, :parse_filter=>[], :render_filter=>[]}"
+    expect(options.extend(Declarative::Inspect).inspect).must_equal "{:private_name=>:artist, :nested=>#<Class:>, :name=>\"artist\", :extend=>#<Class:>, :parse_filter=>[], :render_filter=>[]}"
     assert nested_extend < Representable::Decorator
-    nested_extend.representable_attrs.get(:name).inspect.must_equal "#<Representable::Definition ==>name @options={:private_name=>:name, :name=>\"name\", :parse_filter=>[], :render_filter=>[]}>"
+    expect(nested_extend.representable_attrs.get(:name).inspect).must_equal "#<Representable::Definition ==>name @options={:private_name=>:name, :name=>\"name\", :parse_filter=>[], :render_filter=>[]}>"
   end
 end

--- a/test/skip_getter_test.rb
+++ b/test/skip_getter_test.rb
@@ -26,20 +26,20 @@ class SkipGetterTest < MiniTest::Spec
     album = Album.new("Wild Frontier", Artist.new("Gary Moore"))
     twin  = AlbumTwin.new(album)
 
-    twin.title.must_equal "reitnorF dliW"
-    twin.artist.name.must_equal "GARY MOORE"
+    expect(twin.title).must_equal "reitnorF dliW"
+    expect(twin.artist.name).must_equal "GARY MOORE"
 
     twin.sync # does NOT call getter.
 
-    album.title.must_equal "Wild Frontier"
-    album.artist.name.must_equal "Gary Moore"
+    expect(album.title).must_equal "Wild Frontier"
+    expect(album.artist.name).must_equal "Gary Moore"
 
     # nested hash.
     nested_hash = nil
     twin.sync do |hash|
       nested_hash = hash
     end
-    nested_hash.must_equal({"title"=>"Wild Frontier", "artist"=>{"name"=>"Gary Moore"}})
+    expect(nested_hash).must_equal({"title"=>"Wild Frontier", "artist"=>{"name"=>"Gary Moore"}})
   end
 end
 
@@ -68,8 +68,8 @@ class SkipSetterTest < MiniTest::Spec
   it do
     twin = AlbumTwin.new(Album.new("Wild Frontier", Artist.new("Gary Moore")))
 
-    twin.title.must_equal "Wild Frontier"
-    twin.artist.name.must_equal "Gary Moore"
+    expect(twin.title).must_equal "Wild Frontier"
+    expect(twin.artist.name).must_equal "Gary Moore"
   end
 end
 
@@ -111,18 +111,18 @@ class SkipGetterAndSetterWithChangedTest < MiniTest::Spec
     twin  = AlbumTwin.new(album) # does not call getter (Changed).
 
 
-    twin.title.must_equal "reitnorF dliW"
-    twin.artist.name.must_equal "GARY MOORE"
+    expect(twin.title).must_equal "reitnorF dliW"
+    expect(twin.artist.name).must_equal "GARY MOORE"
 
-    twin.changed?.must_equal false
-    twin.artist.changed?.must_equal false
+    expect(twin.changed?).must_equal false
+    expect(twin.artist.changed?).must_equal false
 
     twin.title = "Self-Entitled"
     twin.artist.name = "Nofx"
 
     twin.sync # does NOT call getter.
 
-    album.title.must_equal "deltitnE-fleS"
-    album.artist.name.must_equal "Nof"
+    expect(album.title).must_equal "deltitnE-fleS"
+    expect(album.artist.name).must_equal "Nof"
   end
 end

--- a/test/twin/builder_test.rb
+++ b/test/twin/builder_test.rb
@@ -26,7 +26,7 @@ class BuilderTest < MiniTest::Spec
   end
 
 
-  it { Twin.build(Model::Song.new).must_be_instance_of Twin }
-  it { Twin.build(Model::Hit.new).must_be_instance_of  Hit }
-  it { Twin.build(Model::Evergreen.new, evergreen: true).must_be_instance_of Evergreen }
+  it { expect(Twin.build(Model::Song.new)).must_be_instance_of Twin }
+  it { expect(Twin.build(Model::Hit.new)).must_be_instance_of  Hit }
+  it { expect(Twin.build(Model::Evergreen.new, evergreen: true)).must_be_instance_of Evergreen }
 end

--- a/test/twin/changed_test.rb
+++ b/test/twin/changed_test.rb
@@ -39,19 +39,19 @@ class ChangedWithSetupTest < MiniTest::Spec
 
   # setup: changed? is always false
   it do
-    twin.changed?(:name).must_equal false
-    twin.changed?.must_equal false
+    expect(twin.changed?(:name)).must_equal false
+    expect(twin.changed?).must_equal false
 
-    twin.songs[0].changed?.must_equal false
-    twin.songs[0].changed?(:title).must_equal false
-    twin.songs[1].changed?.must_equal false
-    twin.songs[1].changed?(:title).must_equal false
+    expect(twin.songs[0].changed?).must_equal false
+    expect(twin.songs[0].changed?(:title)).must_equal false
+    expect(twin.songs[1].changed?).must_equal false
+    expect(twin.songs[1].changed?(:title)).must_equal false
 
-    twin.songs[1].composer.changed?(:name).must_equal false
-    twin.songs[1].composer.changed?.must_equal false
+    expect(twin.songs[1].composer.changed?(:name)).must_equal false
+    expect(twin.songs[1].composer.changed?).must_equal false
 
-    twin.artist.changed?(:name).must_equal false
-    twin.artist.changed?.must_equal false
+    expect(twin.artist.changed?(:name)).must_equal false
+    expect(twin.artist.changed?).must_equal false
   end
 
   # only when a property is assigned, it's changed.
@@ -62,46 +62,46 @@ class ChangedWithSetupTest < MiniTest::Spec
     twin.songs[1].composer.name= "Ingemar Jansson & Mikael Danielsson"
     twin.artist.name = "No Fun At All"
 
-    twin.changed?(:name).must_equal true
-    twin.changed?.must_equal true
+    expect(twin.changed?(:name)).must_equal true
+    expect(twin.changed?).must_equal true
 
-    twin.songs[0].changed?.must_equal true
-    twin.songs[0].changed?(:title).must_equal true
-    twin.songs[1].changed?.must_equal true
-    twin.songs[1].changed?(:title).must_equal true
+    expect(twin.songs[0].changed?).must_equal true
+    expect(twin.songs[0].changed?(:title)).must_equal true
+    expect(twin.songs[1].changed?).must_equal true
+    expect(twin.songs[1].changed?(:title)).must_equal true
 
-    twin.songs[1].composer.changed?(:name).must_equal true
-    twin.songs[1].composer.changed?.must_equal true
+    expect(twin.songs[1].composer.changed?(:name)).must_equal true
+    expect(twin.songs[1].composer.changed?).must_equal true
 
-    twin.artist.changed?(:name).must_equal true
-    twin.artist.changed?.must_equal true
+    expect(twin.artist.changed?(:name)).must_equal true
+    expect(twin.artist.changed?).must_equal true
 
     # you can also ask for nested twins by name.
-    twin.changed?(:songs).must_equal true
-    twin.songs[0].changed?(:composer).must_equal false
-    twin.songs[1].changed?(:composer).must_equal true
-    twin.changed?(:artist).must_equal true
+    expect(twin.changed?(:songs)).must_equal true
+    expect(twin.songs[0].changed?(:composer)).must_equal false
+    expect(twin.songs[1].changed?(:composer)).must_equal true
+    expect(twin.changed?(:artist)).must_equal true
   end
 
   # nested changes should propagate up.
   it do
-    twin.changed?.must_equal false
+    expect(twin.changed?).must_equal false
 
     twin.songs[1].composer.name = "Nofx"
 
-    twin.changed?.must_equal true
+    expect(twin.changed?).must_equal true
 
     assert twin.songs.changed?
-    twin.songs[1].changed?.must_equal true
-    twin.songs[0].changed?.must_equal false
+    expect(twin.songs[1].changed?).must_equal true
+    expect(twin.songs[0].changed?).must_equal false
 
-    twin.artist.changed?.must_equal false
+    expect(twin.artist.changed?).must_equal false
   end
 
   # setting identical value doesn't change.
   it do
     twin.name = "The Rest Is Silence"
-    twin.changed?.must_equal false
+    expect(twin.changed?).must_equal false
   end
 end
 
@@ -119,18 +119,18 @@ class ChangedWithCoercionTest < MiniTest::Spec
 
   it do
     twin = SongTwin.new(Song.new)
-    twin.changed?(:released).must_equal false
+    expect(twin.changed?(:released)).must_equal false
     twin.released = 'true'
-    twin.released.must_equal true
-    twin.changed?(:released).must_equal true
+    expect(twin.released).must_equal true
+    expect(twin.changed?(:released)).must_equal true
   end
 
   it do
     twin = SongTwin.new(Song.new(true))
-    twin.changed?(:released).must_equal false
+    expect(twin.changed?(:released)).must_equal false
     twin.released = 'true' # it coerces, then assigns, then compares, which makes this NOT changed.
-    twin.changed?(:released).must_equal false
+    expect(twin.changed?(:released)).must_equal false
     twin.released = 'false'
-    twin.changed?(:released).must_equal true
+    expect(twin.changed?(:released)).must_equal true
   end
 end

--- a/test/twin/coercion_test.rb
+++ b/test/twin/coercion_test.rb
@@ -37,9 +37,9 @@ class CoercionTest < MiniTest::Spec
     }
 
     it "NOT coerce values in setup" do
-      subject.released_at.must_equal "31/03/1981"
-      subject.hit.length.must_equal "312"
-      subject.band.label.value.must_equal "9999.99"
+      expect(subject.released_at).must_equal "31/03/1981"
+      expect(subject.hit.length).must_equal "312"
+      expect(subject.band.label.value).must_equal "9999.99"
     end
 
 
@@ -49,11 +49,11 @@ class CoercionTest < MiniTest::Spec
       subject.hit.length = "312"
       subject.band.label.value = "9999.99"
 
-      subject.released_at.must_be_kind_of DateTime
-      subject.released_at.must_equal DateTime.parse("30/03/1981")
-      subject.hit.length.must_equal 312
-      subject.hit.good.must_be_nil
-      subject.band.label.value.must_equal 9999.99
+      expect(subject.released_at).must_be_kind_of DateTime
+      expect(subject.released_at).must_equal DateTime.parse("30/03/1981")
+      expect(subject.hit.length).must_equal 312
+      expect(subject.hit.good).must_be_nil
+      expect(subject.band.label.value).must_equal 9999.99
     end
   end
 
@@ -69,9 +69,9 @@ class CoercionTest < MiniTest::Spec
     end
 
     it "coerce values in setup and when using a setter" do
-      subject.id.must_equal 1
+      expect(subject.id).must_equal 1
       subject.id = "2"
-      subject.id.must_equal 2
+      expect(subject.id).must_equal 2
     end
   end
 
@@ -94,23 +94,23 @@ class CoercionTest < MiniTest::Spec
     end
 
     it "coerce values correctly" do
-      subject.date_of_birth.must_equal Date.parse('1990-01-12')
-      subject.date_of_death_by_unicorns.must_equal Date.parse('2037-02-18')
+      expect(subject.date_of_birth).must_equal Date.parse('1990-01-12')
+      expect(subject.date_of_death_by_unicorns).must_equal Date.parse('2037-02-18')
     end
 
     it "coerce empty values to nil when using option nilify: true" do
       subject.date_of_birth = ""
-      subject.date_of_birth.must_be_nil
+      expect(subject.date_of_birth).must_be_nil
     end
 
     it "coerce empty values to nil when using dry-types | operator" do
       subject.date_of_death_by_unicorns = ""
-      subject.date_of_death_by_unicorns.must_be_nil
+      expect(subject.date_of_death_by_unicorns).must_be_nil
     end
 
     it "converts blank string to nil, without :type option" do
       subject.id = ""
-      subject.id.must_be_nil
+      expect(subject.id).must_be_nil
     end
   end
 end
@@ -135,13 +135,13 @@ class CoercionTypingTest < MiniTest::Spec
     # with type: Dry::Types::Strict::String
     # assert_raises(Dry::Types::ConstraintError) { twin.title = nil }
     twin.title = nil
-    twin.title.must_be_nil
+    expect(twin.title).must_be_nil
 
     twin.title = "Yo"
-    twin.title.must_equal "Yo"
+    expect(twin.title).must_equal "Yo"
 
     twin.title = ""
-    twin.title.must_equal ""
+    expect(twin.title).must_equal ""
 
     assert_raises(Dry::Types::ConstraintError) { twin.title = :bla }
     assert_raises(Dry::Types::ConstraintError) { twin.title = 1 }
@@ -167,16 +167,16 @@ class CoercionTypingTest < MiniTest::Spec
 
     # assert_raises(Dry::Types::ConstraintError) { twin.title = nil } # in form, we either have a blank string or the key's not present at all.
     twin.title = nil
-    twin.title.must_be_nil
+    expect(twin.title).must_be_nil
 
     twin.title = "" # nilify blank strings
-    twin.title.must_be_nil
+    expect(twin.title).must_be_nil
 
     twin.title = "Yo"
-    twin.title.must_equal "Yo"
+    expect(twin.title).must_equal "Yo"
 
     # twin.enabled = " TRUE"
-    # twin.enabled.must_equal true
+    #expect(twin.enabled).must_equal true
   end
 end
 

--- a/test/twin/collection_test.rb
+++ b/test/twin/collection_test.rb
@@ -33,9 +33,9 @@ class TwinCollectionTest < MiniTest::Spec
     it do
       twin = Twin::Album.new(album)
 
-      twin.songs.size.must_equal 1
-      twin.songs[0].title.must_equal "Broken"
-      twin.songs.must_be_instance_of Disposable::Twin::Collection
+      expect(twin.songs.size).must_equal 1
+      expect(twin.songs[0].title).must_equal "Broken"
+      expect(twin.songs).must_be_instance_of Disposable::Twin::Collection
 
     end
   end
@@ -44,10 +44,10 @@ class TwinCollectionTest < MiniTest::Spec
     let (:album) { Model::Album.new(1, "The Rest Is Silence", [Model::Song.new(3), Model::Song.new(4)]) }
     let (:twin) { Twin::Album.new(album) }
 
-    it { twin.songs.find_by(id: 1).must_be_nil }
-    it { twin.songs.find_by(id: 3).must_equal twin.songs[0] }
-    it { twin.songs.find_by(id: 4).must_equal twin.songs[1] }
-    it { twin.songs.find_by(id: "4").must_equal twin.songs[1] }
+    it { expect(twin.songs.find_by(id: 1)).must_be_nil }
+    it { expect(twin.songs.find_by(id: 3)).must_equal twin.songs[0] }
+    it { expect(twin.songs.find_by(id: 4)).must_equal twin.songs[1] }
+    it { expect(twin.songs.find_by(id: "4")).must_equal twin.songs[1] }
   end
 end
 
@@ -92,31 +92,31 @@ class TwinCollectionActiveRecordTest < MiniTest::Spec
     twin.songs << song1 # assuming that we add AR model here.
     twin.songs << song2
 
-    twin.songs.size.must_equal 2
+    expect(twin.songs.size).must_equal 2
 
-    twin.songs[0].must_be_instance_of Twin::Song # twin wraps << added in twin.
-    twin.songs[1].must_be_instance_of Twin::Song
+    expect(twin.songs[0]).must_be_instance_of Twin::Song # twin wraps << added in twin.
+    expect(twin.songs[1]).must_be_instance_of Twin::Song
 
-    # twin.songs[0].persisted?.must_equal false
-    twin.songs[0].send(:model).persisted?.must_equal false
-    twin.songs[1].send(:model).persisted?.must_equal true
+    # expect(twin.songs[0].persisted?).must_equal false
+    expect(twin.songs[0].send(:model).persisted?).must_equal false
+    expect(twin.songs[1].send(:model).persisted?).must_equal true
 
-    album.songs.size.must_equal 0 # nothing synced, yet.
+    expect(album.songs.size).must_equal 0 # nothing synced, yet.
 
     # sync: delete removed items, add new?
 
     # save
     twin.save
 
-    album.persisted?.must_equal true
-    album.name.must_equal "The Rest Is Silence"
+    expect(album.persisted?).must_equal true
+    expect(album.name).must_equal "The Rest Is Silence"
 
-    album.songs.size.must_equal 2 # synced!
+    expect(album.songs.size).must_equal 2 # synced!
 
-    album.songs[0].persisted?.must_equal true
-    album.songs[1].persisted?.must_equal true
-    album.songs[0].title.must_equal "Snorty Pacifical Rascal"
-    album.songs[1].title.must_equal "At Any Cost"
+    expect(album.songs[0].persisted?).must_equal true
+    expect(album.songs[1].persisted?).must_equal true
+    expect(album.songs[0].title).must_equal "Snorty Pacifical Rascal"
+    expect(album.songs[1].title).must_equal "At Any Cost"
   end
 
   # test with adding to existing collection [song1] << song2
@@ -128,20 +128,20 @@ class TwinCollectionActiveRecordTest < MiniTest::Spec
     it do
       twin.songs.delete(twin.songs.first)
 
-      twin.songs.size.must_equal 0
-      album.songs.size.must_equal 1 # not synced, yet.
+      expect(twin.songs.size).must_equal 0
+      expect(album.songs.size).must_equal 1 # not synced, yet.
 
       twin.save
 
-      twin.songs.size.must_equal 0
-      album.songs.size.must_equal 0
-      song1.persisted?.must_equal true
+      expect(twin.songs.size).must_equal 0
+      expect(album.songs.size).must_equal 0
+      expect(song1.persisted?).must_equal true
     end
 
     # non-existant delete.
     it do
       twin.songs.delete("non-existant") # won't delete anything.
-      twin.songs.size.must_equal 1
+      expect(twin.songs.size).must_equal 1
     end
   end
 
@@ -151,14 +151,14 @@ class TwinCollectionActiveRecordTest < MiniTest::Spec
     it do
       twin.songs.destroy(twin.songs.first)
 
-      twin.songs.size.must_equal 0
-      album.songs.size.must_equal 1 # not synced, yet.
+      expect(twin.songs.size).must_equal 0
+      expect(album.songs.size).must_equal 1 # not synced, yet.
 
       twin.save
 
-      twin.songs.size.must_equal 0
-      album.songs.size.must_equal 0
-      song1.persisted?.must_equal false
+      expect(twin.songs.size).must_equal 0
+      expect(album.songs.size).must_equal 0
+      expect(song1.persisted?).must_equal false
     end
   end
 
@@ -169,11 +169,11 @@ class TwinCollectionActiveRecordTest < MiniTest::Spec
     it do
       twin = Twin::Album.new(album)
 
-      twin.songs.added.must_equal []
+      expect(twin.songs.added).must_equal []
       twin.songs << song2
-      twin.songs.added.must_equal [twin.songs[1]]
+      expect(twin.songs.added).must_equal [twin.songs[1]]
       twin.songs.insert(2, Song.new)
-      twin.songs.added.must_equal [twin.songs[1], twin.songs[2]]
+      expect(twin.songs.added).must_equal [twin.songs[1], twin.songs[2]]
 
       # TODO: what to do if we override an item (insert)?
     end
@@ -185,20 +185,20 @@ class TwinCollectionActiveRecordTest < MiniTest::Spec
     it do
       twin = Twin::Album.new(album)
 
-      twin.songs.deleted.must_equal []
+      expect(twin.songs.deleted).must_equal []
 
       twin.songs.delete(deleted1 = twin.songs[-1])
       twin.songs.delete(deleted2 = twin.songs[-1])
 
-      twin.songs.must_equal [twin.songs[0]]
+      expect(twin.songs).must_equal [twin.songs[0]]
 
-      twin.songs.deleted.must_equal [deleted1, deleted2]
+      expect(twin.songs.deleted).must_equal [deleted1, deleted2]
     end
 
     # non-existant delete.
     it do
       twin.songs.delete("non-existant") # won't delete anything.
-      twin.songs.deleted.must_equal []
+      expect(twin.songs.deleted).must_equal []
     end
   end
 end
@@ -223,24 +223,24 @@ class CollectionUnitTest < MiniTest::Spec
 
   # #insert(index, model)
   it do
-    collection.insert(0, Model::Album.new).must_be_instance_of Twin::Album
+    expect(collection.insert(0, Model::Album.new)).must_be_instance_of Twin::Album
   end
 
   # #append(model)
   it do
-    collection.append(Model::Album.new).must_be_instance_of Twin::Album
-    collection[0].must_be_instance_of Twin::Album
+    expect(collection.append(Model::Album.new)).must_be_instance_of Twin::Album
+    expect(collection[0]).must_be_instance_of Twin::Album
 
     # allows subsequent calls.
     collection.append(Model::Album.new)
-    collection[1].must_be_instance_of Twin::Album
+    expect(collection[1]).must_be_instance_of Twin::Album
 
-    collection.size.must_equal 2
+    expect(collection.size).must_equal 2
   end
 
   # #<<
   it do
-    (collection << Model::Album.new).must_be_instance_of Array
-    collection[0].must_be_instance_of Twin::Album
+    expect((collection << Model::Album.new)).must_be_instance_of Array
+    expect(collection[0]).must_be_instance_of Twin::Album
   end
 end

--- a/test/twin/composition_test.rb
+++ b/test/twin/composition_test.rb
@@ -26,34 +26,34 @@ class TwinCompositionTest < MiniTest::Spec
   let (:request) { Request.new(song: song, requester: requester) }
 
   it do
-    request.song_title.must_equal "Extraction"
-    request.song_id.must_equal 2
-    request.name.must_equal "Greg Howe"
-    request.id.must_equal 1
+    expect(request.song_title).must_equal "Extraction"
+    expect(request.song_id).must_equal 2
+    expect(request.name).must_equal "Greg Howe"
+    expect(request.id).must_equal 1
 
     request.song_title = "Tease"
     request.name = "Wooten"
 
 
-    request.song_title.must_equal "Tease"
-    request.name.must_equal "Wooten"
+    expect(request.song_title).must_equal "Tease"
+    expect(request.name).must_equal "Wooten"
 
     # does not write to model.
-    song.title.must_equal "Extraction"
-    requester.name.must_equal "Greg Howe"
+    expect(song.title).must_equal "Extraction"
+    expect(requester.name).must_equal "Greg Howe"
 
 
     res = request.save
-    res.must_equal true
+    expect(res).must_equal true
 
     # make sure models got synced and saved.
-    song.id.must_equal 2
-    song.title.must_equal "Tease"
-    requester.id.must_equal 1
-    requester.name.must_equal "Wooten"
+    expect(song.id).must_equal 2
+    expect(song.title).must_equal "Tease"
+    expect(requester.id).must_equal 1
+    expect(requester.name).must_equal "Wooten"
 
-    song.saved?.must_equal true
-    requester.saved?.must_equal true
+    expect(song.saved?).must_equal true
+    expect(requester.saved?).must_equal true
   end
 
   # save with block.
@@ -63,8 +63,8 @@ class TwinCompositionTest < MiniTest::Spec
     request.captcha = "Awesome!"
 
     # does not write to model.
-    song.title.must_equal "Extraction"
-    requester.name.must_equal "Greg Howe"
+    expect(song.title).must_equal "Extraction"
+    expect(requester.name).must_equal "Greg Howe"
 
 
     nested_hash = nil
@@ -72,13 +72,13 @@ class TwinCompositionTest < MiniTest::Spec
       nested_hash = hash
     end
 
-    nested_hash.must_equal(:song=>{"title"=>"Tease", "id"=>2}, :requester=>{"name"=>"Wooten", "id"=>1, "captcha"=>"Awesome!"})
+    expect(nested_hash).must_equal(:song=>{"title"=>"Tease", "id"=>2}, :requester=>{"name"=>"Wooten", "id"=>1, "captcha"=>"Awesome!"})
   end
 
   # save with one unsaveable model.
     #save returns result.
   it do
     song.instance_eval { def save; false; end }
-    request.save.must_equal false
+    expect(request.save).must_equal false
   end
 end

--- a/test/twin/default_test.rb
+++ b/test/twin/default_test.rb
@@ -19,28 +19,28 @@ class DefaultTest < Minitest::Spec
   # all given.
   it do
     twin = Twin.new(Song.new("Anarchy Camp", false, true, "Punk", Composer.new("Nofx")))
-    twin.title.must_equal "Anarchy Camp"
-    twin.genre.must_equal "Punk"
-    twin.composer.name.must_equal "Nofx"
-    twin.published.must_equal true
-    twin.new_album.must_equal false
+    expect(twin.title).must_equal "Anarchy Camp"
+    expect(twin.genre).must_equal "Punk"
+    expect(twin.composer.name).must_equal "Nofx"
+    expect(twin.published).must_equal true
+    expect(twin.new_album).must_equal false
   end
 
   # defaults, please.
   it do
     twin = Twin.new(Song.new)
-    twin.title.must_equal "Medio-Core"
-    twin.composer.name.must_equal "NOFX"
-    twin.genre.must_equal "Punk Rock DefaultTest::Song"
-    twin.published.must_equal false
-    twin.new_album.must_equal true
+    expect(twin.title).must_equal "Medio-Core"
+    expect(twin.composer.name).must_equal "NOFX"
+    expect(twin.genre).must_equal "Punk Rock DefaultTest::Song"
+    expect(twin.published).must_equal false
+    expect(twin.new_album).must_equal true
   end
 
   # false value is not defaulted.
   it do
     twin = Twin.new(Song.new(false, false))
-    twin.title.must_equal false
-    twin.new_album.must_equal false
+    expect(twin.title).must_equal false
+    expect(twin.new_album).must_equal false
   end
 
   describe "inheritance" do
@@ -51,7 +51,7 @@ class DefaultTest < Minitest::Spec
     class MegaTwin < SuperTwin
     end
 
-    it { MegaTwin.new(Composer.new).name.must_equal "n/a" }
+    it { expect(MegaTwin.new(Composer.new).name).must_equal "n/a" }
   end
 end
 
@@ -65,8 +65,8 @@ class DefaultAndVirtualTest < Minitest::Spec
 
   it do
     twin = Twin.new(Object.new)
-    twin.title.must_equal "0"
-    # twin.changed.must_equal []
+    expect(twin.title).must_equal "0"
+    # expect(twin.changed).must_equal []
   end
 end
 

--- a/test/twin/expose_test.rb
+++ b/test/twin/expose_test.rb
@@ -28,28 +28,28 @@ class TwinExposeTest < MiniTest::Spec
   let (:request) { Request.new(song) }
 
   it do
-    request.song_title.must_equal "Extraction"
-    request.id.must_equal 2
+    expect(request.song_title).must_equal "Extraction"
+    expect(request.id).must_equal 2
 
     request.song_title = "Tease"
     request.id = 1
 
 
-    request.song_title.must_equal "Tease"
-    request.id.must_equal 1
+    expect(request.song_title).must_equal "Tease"
+    expect(request.id).must_equal 1
 
     # does not write to model.
-    song.title.must_equal "Extraction"
-    song.id.must_equal 2
+    expect(song.title).must_equal "Extraction"
+    expect(song.id).must_equal 2
 
     request.save
 
     # make sure models got synced and saved.
-    song.id.must_equal 1
-    song.title.must_equal "Tease"
-    song.album.must_equal album # nested objects don't get twinned or anything.
+    expect(song.id).must_equal 1
+    expect(song.title).must_equal "Tease"
+    expect(song.album).must_equal album # nested objects don't get twinned or anything.
 
-    song.saved?.must_equal true
+    expect(song.saved?).must_equal true
   end
 
   # save with block.
@@ -63,11 +63,11 @@ class TwinExposeTest < MiniTest::Spec
       nested_hash = hash
     end
 
-    nested_hash.must_equal({"title"=>"Tease", "id"=>1, "captcha" => "Awesome!", "album"=>{"getName"=>"Appeal To Reason"}})
+    expect(nested_hash).must_equal({"title"=>"Tease", "id"=>1, "captcha" => "Awesome!", "album"=>{"getName"=>"Appeal To Reason"}})
 
     # does not write to model.
-    song.title.must_equal "Extraction"
-    song.id.must_equal 2
-    album.getName.must_equal "Appeal To Reason"
+    expect(song.title).must_equal "Extraction"
+    expect(song.id).must_equal 2
+    expect(album.getName).must_equal "Appeal To Reason"
   end
 end

--- a/test/twin/feature_test.rb
+++ b/test/twin/feature_test.rb
@@ -44,14 +44,14 @@ class FeatureTest < MiniTest::Spec
   let (:form) { AlbumForm.new(album) }
 
   it do
-    form.date.must_equal "May 16"
-    form.artist.date.must_equal "May 16"
-    form.songs[0].date.must_equal "May 16"
-    form.songs[1].date.must_equal "May 16"
-    form.songs[1].composer.date.must_equal "May 16"
-    form.songs[1].wont_be_kind_of(Instrument)
-    form.songs[1].composer.must_be_kind_of(Instrument)
-    form.songs[1].composer.instrument.must_equal "Violins"
-    form.artist.date.must_equal "May 16"
+    expect(form.date).must_equal "May 16"
+    expect(form.artist.date).must_equal "May 16"
+    expect(form.songs[0].date).must_equal "May 16"
+    expect(form.songs[1].date).must_equal "May 16"
+    expect(form.songs[1].composer.date).must_equal "May 16"
+    expect(form.songs[1]).wont_be_kind_of(Instrument)
+    expect(form.songs[1].composer).must_be_kind_of(Instrument)
+    expect(form.songs[1].composer.instrument).must_equal "Violins"
+    expect(form.artist.date).must_equal "May 16"
   end
 end

--- a/test/twin/from_collection_test.rb
+++ b/test/twin/from_collection_test.rb
@@ -20,10 +20,10 @@ class TwinFromCollectionDecoratorTest < MiniTest::Spec
     it do
       twined_collection = Twin::Artist.from_collection(collection)
 
-      twined_collection[0].must_be_instance_of Twin::Artist
-      twined_collection[0].model.must_equal artist1
-      twined_collection[1].must_be_instance_of Twin::Artist
-      twined_collection[1].model.must_equal artist2
+      expect(twined_collection[0]).must_be_instance_of Twin::Artist
+      expect(twined_collection[0].model).must_equal artist1
+      expect(twined_collection[1]).must_be_instance_of Twin::Artist
+      expect(twined_collection[1].model).must_equal artist2
     end
   end
 end

--- a/test/twin/from_test.rb
+++ b/test/twin/from_test.rb
@@ -27,8 +27,8 @@ class FromTest < MiniTest::Spec
   let (:twin)     { Twin::Album.new(album) }
 
   it do
-    twin.full_name.must_equal "Black Sails In The Sunset"
-    twin.artist.name.must_equal "AFI"
+    expect(twin.full_name).must_equal "Black Sails In The Sunset"
+    expect(twin.artist.name).must_equal "AFI"
 
     twin.save
 

--- a/test/twin/hash_test.rb
+++ b/test/twin/hash_test.rb
@@ -29,31 +29,31 @@ class HashTest < MiniTest::Spec
 
   it "allows reading from existing hash" do
     model = Model.new(1, {})
-    model.inspect.must_equal "#<struct HashTest::Model id=1, content={}>"
+    expect(model.inspect).must_equal "#<struct HashTest::Model id=1, content={}>"
 
     song = Song.new(model)
-    song.id.must_equal 1
-    song.content.title.must_be_nil
-    song.content.band.name.must_be_nil
-    song.content.band.label.location.must_be_nil
-    song.content.releases.must_equal []
+    expect(song.id).must_equal 1
+    expect(song.content.title).must_be_nil
+    expect(song.content.band.name).must_be_nil
+    expect(song.content.band.label.location).must_be_nil
+    expect(song.content.releases).must_equal []
 
     # model's hash hasn't changed.
-    model.inspect.must_equal "#<struct HashTest::Model id=1, content={}>"
+    expect(model.inspect).must_equal "#<struct HashTest::Model id=1, content={}>"
   end
 
   it "defaults to hash when value is nil" do
     model = Model.new(1)
-    model.inspect.must_equal "#<struct HashTest::Model id=1, content=nil>"
+    expect(model.inspect).must_equal "#<struct HashTest::Model id=1, content=nil>"
 
     song = Song.new(model)
-    song.id.must_equal 1
-    song.content.title.must_be_nil
-    song.content.band.name.must_be_nil
-    song.content.band.label.location.must_be_nil
+    expect(song.id).must_equal 1
+    expect(song.content.title).must_be_nil
+    expect(song.content.band.name).must_be_nil
+    expect(song.content.band.label.location).must_be_nil
 
     # model's hash hasn't changed.
-    model.inspect.must_equal "#<struct HashTest::Model id=1, content=nil>"
+    expect(model.inspect).must_equal "#<struct HashTest::Model id=1, content=nil>"
   end
 
   it "#sync writes to model" do
@@ -64,7 +64,7 @@ class HashTest < MiniTest::Spec
 
     song.sync
 
-    model.inspect.must_equal "#<struct HashTest::Model id=nil, content={\"band\"=>{\"label\"=>{\"location\"=>\"San Francisco\"}}, \"releases\"=>[]}>"
+    expect(model.inspect).must_equal "#<struct HashTest::Model id=nil, content={\"band\"=>{\"label\"=>{\"location\"=>\"San Francisco\"}}, \"releases\"=>[]}>"
   end
 
   it "#appends to collections" do
@@ -76,7 +76,7 @@ class HashTest < MiniTest::Spec
 
     song.sync
 
-    model.inspect.must_equal "#<struct HashTest::Model id=nil, content={\"band\"=>{\"label\"=>{}}, \"releases\"=>[{\"version\"=>1}]}>"
+    expect(model.inspect).must_equal "#<struct HashTest::Model id=nil, content={\"band\"=>{\"label\"=>{}}, \"releases\"=>[{\"version\"=>1}]}>"
   end
 
   it "doesn't erase existing, undeclared content" do
@@ -88,7 +88,7 @@ class HashTest < MiniTest::Spec
     # puts song.content.class.ancestors
     song.sync
 
-    model.inspect.must_equal "#<struct HashTest::Model id=nil, content={\"artist\"=>{}, \"band\"=>{\"label\"=>{\"location\"=>\"San Francisco\"}}, \"releases\"=>[]}>"
+    expect(model.inspect).must_equal "#<struct HashTest::Model id=nil, content={\"artist\"=>{}, \"band\"=>{\"label\"=>{\"location\"=>\"San Francisco\"}}, \"releases\"=>[]}>"
   end
 
   it "doesn't erase existing, undeclared content in existing content" do
@@ -99,7 +99,7 @@ class HashTest < MiniTest::Spec
 
     song.sync
 
-    model.inspect.must_equal "#<struct HashTest::Model id=nil, content={\"band\"=>{\"label\"=>{\"owner\"=>\"Brett Gurewitz\", \"location\"=>\"San Francisco\"}, \"genre\"=>\"Punkrock\"}, \"releases\"=>[]}>"
+    expect(model.inspect).must_equal "#<struct HashTest::Model id=nil, content={\"band\"=>{\"label\"=>{\"owner\"=>\"Brett Gurewitz\", \"location\"=>\"San Francisco\"}, \"genre\"=>\"Punkrock\"}, \"releases\"=>[]}>"
   end
 
 
@@ -125,9 +125,9 @@ class HashTest < MiniTest::Spec
 
     it "includes features into all nested twins" do
       song = Hit.new(Model.new)
-      song.uuid.must_equal "1224"
-      song.content.uuid.must_equal "1224"
-      song.content.band.uuid.must_equal "1224"
+      expect(song.uuid).must_equal "1224"
+      expect(song.content.uuid).must_equal "1224"
+      expect(song.content.band.uuid).must_equal "1224"
     end
   end
 
@@ -149,9 +149,9 @@ class HashTest < MiniTest::Spec
     it "coerces" do
       song = Coercing.new(Model.new(1))
       song.id = "9"
-      song.id.must_equal 9
+      expect(song.id).must_equal 9
       song.content.band.name = 18
-      song.content.band.name.must_equal "18"
+      expect(song.content.band.name).must_equal "18"
     end
   end
 
@@ -190,18 +190,18 @@ class HashTest < MiniTest::Spec
       song = Unnesting.new(model)
 
       # singular scalar accessors
-      song.content.title.must_equal "Bedroom Eyes"
-      song.title.must_equal "Bedroom Eyes"
+      expect(song.content.title).must_equal "Bedroom Eyes"
+      expect(song.title).must_equal "Bedroom Eyes"
 
       song.title = "Notorious"
-      song.title.must_equal "Notorious"
-      song.content.title.must_equal "Notorious"
+      expect(song.title).must_equal "Notorious"
+      expect(song.content.title).must_equal "Notorious"
 
       # singular nested accessors
-      song.band.name.must_be_nil
-      song.content.band.name.must_be_nil
+      expect(song.band.name).must_be_nil
+      expect(song.content.band.name).must_be_nil
       song.band.name = "Duran Duran"
-      song.band.name.must_equal "Duran Duran"
+      expect(song.band.name).must_equal "Duran Duran"
     end
   end
 
@@ -237,18 +237,18 @@ class HashTest < MiniTest::Spec
 
       song1 = contract.songs[0]
 
-      song1.title.must_equal "Sherry"
-      song1.band.name.must_equal 'The Four Seasons'
-      song1.band.label.location.must_equal 'US'
-      song1.featured_artists[0].name.must_equal 'Frankie Valli'
-      song1.featured_artists[1].name.must_equal 'The Variatones'
+      expect(song1.title).must_equal "Sherry"
+      expect(song1.band.name).must_equal 'The Four Seasons'
+      expect(song1.band.label.location).must_equal 'US'
+      expect(song1.featured_artists[0].name).must_equal 'Frankie Valli'
+      expect(song1.featured_artists[1].name).must_equal 'The Variatones'
 
       song2 = contract.songs[1]
 
-      song2.title.must_equal "Walk Like a Man"
-      song2.band.name.must_equal 'The Four Seasons'
-      song2.band.label.location.must_equal 'US'
-      song2.featured_artists[0].name.must_equal 'Frankie Valli'
+      expect(song2.title).must_equal "Walk Like a Man"
+      expect(song2.band.name).must_equal 'The Four Seasons'
+      expect(song2.band.label.location).must_equal 'US'
+      expect(song2.featured_artists[0].name).must_equal 'Frankie Valli'
     end
   end
 end

--- a/test/twin/inherit_test.rb
+++ b/test/twin/inherit_test.rb
@@ -40,20 +40,20 @@ class InheritTest < MiniTest::Spec
 
   # definitions are not shared.
   it do
-    Twin::Album.definitions.get(:name).extend(Declarative::Inspect).inspect.must_equal "#<Disposable::Twin::Definition: @options={:fromage=>:_name, :private_name=>:name, :name=>\"name\"}>"
-    Twin::Compilation.definitions.get(:name).extend(Declarative::Inspect).inspect.must_equal "#<Disposable::Twin::Definition: @options={:fromage=>:_name, :private_name=>:name, :name=>\"name\", :writeable=>false}>" # FIXME: where did :inherit go?
+    expect(Twin::Album.definitions.get(:name).extend(Declarative::Inspect).inspect).must_equal "#<Disposable::Twin::Definition: @options={:fromage=>:_name, :private_name=>:name, :name=>\"name\"}>"
+    expect(Twin::Compilation.definitions.get(:name).extend(Declarative::Inspect).inspect).must_equal "#<Disposable::Twin::Definition: @options={:fromage=>:_name, :private_name=>:name, :name=>\"name\", :writeable=>false}>" # FIXME: where did :inherit go?
   end
 
 
   let (:album) { Model::Album.new("In The Meantime And Inbetween Time", [], Model::Artist.new) }
 
-  it { Twin::Album.new(album).artist.artist_id.must_equal 1 }
+  it { expect(Twin::Album.new(album).artist.artist_id).must_equal 1 }
 
   # inherit inline twins when not overriding.
-  it { Twin::EmptyCompilation.new(album).artist.artist_id.must_equal 1 }
+  it { expect(Twin::EmptyCompilation.new(album).artist.artist_id).must_equal 1 }
 
   # inherit inline twins when overriding.
-  it { Twin::Compilation.new(album).artist.artist_id.must_equal 1 }
+  it { expect(Twin::Compilation.new(album).artist.artist_id).must_equal 1 }
 
   describe "custom accessors get inherited" do
     class Singer < Disposable::Twin
@@ -75,11 +75,11 @@ class InheritTest < MiniTest::Spec
 
     it do
       artist = Star.new(model)
-      artist.name.must_equal("neewolleh")
+      expect(artist.name).must_equal("neewolleh")
 
       artist.name = "HELLOWEEN"
       # artist.with_custom_setter = "this gets ignored"
-      artist.name.must_equal("neewolleh")
+      expect(artist.name).must_equal("neewolleh")
     end
   end
 end

--- a/test/twin/inheritance_test.rb
+++ b/test/twin/inheritance_test.rb
@@ -20,7 +20,7 @@ class InheritanceTest < Minitest::Spec
 
   it do
     twin = Twin.new(song)
-    twin.id.must_equal 0
+    expect(twin.id).must_equal 0
   end
 
   class TwinComposition < Disposable::Twin
@@ -32,9 +32,9 @@ class InheritanceTest < Minitest::Spec
 
   it do
     twin = TwinComposition.new(song: song)
-    twin.id.must_equal 0
+    expect(twin.id).must_equal 0
     twin.id= 3
-    twin.id.must_equal 3
+    expect(twin.id).must_equal 3
   end
 
 
@@ -50,7 +50,7 @@ class InheritanceTest < Minitest::Spec
 
   it do
     twin = TwinCompositionDefineMethod.new(song: song)
-    twin.id.must_equal 9
+    expect(twin.id).must_equal 9
   end
 
 
@@ -66,8 +66,8 @@ class InheritanceTest < Minitest::Spec
     end
 
     it do
-      TwinWithFrom.new(song).id.must_equal 1
-      InheritingFrom.new(song).id.must_equal 1
+      expect(TwinWithFrom.new(song).id).must_equal 1
+      expect(InheritingFrom.new(song).id).must_equal 1
     end
   end
 end

--- a/test/twin/parent_test.rb
+++ b/test/twin/parent_test.rb
@@ -27,15 +27,15 @@ class TwinParentTest < MiniTest::Spec
 
   let (:album) { Album.new(Model::Album.new(1, Model::Artist.new("Helloween"), [Model::Song.new("I'm Alive", Model::Artist.new("Kai Hansen"))])) }
 
-  it { album.parent.must_be_nil }
-  it { album.artist.parent.must_equal album }
-  it { album.songs[0].parent.must_equal album }
-  it { album.songs[0].composer.parent.must_equal album.songs[0] }
+  it { expect(album.parent).must_be_nil }
+  it { expect(album.artist.parent).must_equal album }
+  it { expect(album.songs[0].parent).must_equal album }
+  it { expect(album.songs[0].composer.parent).must_equal album.songs[0] }
 
   describe "Collection#append" do
     it do
       album.songs.append(Model::Song.new)
-      album.songs[1].parent.must_equal album
+      expect(album.songs[1].parent).must_equal album
     end
   end
 end

--- a/test/twin/property_processor_test.rb
+++ b/test/twin/property_processor_test.rb
@@ -23,14 +23,14 @@ class PropertyProcessorTest < Minitest::Spec
 	    called = []
 	    Disposable::Twin::PropertyProcessor.new(twin.class.definitions.get(:songs), twin).() { |v, i| called << [v.model, i] }
 
-	    called.inspect.must_equal %{[[#<struct PropertyProcessorTest::Song id=1>, 0], [#<struct PropertyProcessorTest::Song id=2>, 1]]}
+	    expect(called.inspect).must_equal %{[[#<struct PropertyProcessorTest::Song id=1>, 0], [#<struct PropertyProcessorTest::Song id=2>, 1]]}
   	end
 
   	it "yields twin" do
 	    called = []
 	    Disposable::Twin::PropertyProcessor.new(twin.class.definitions.get(:songs), twin).() { |v| called << [v.model] }
 
-	    called.inspect.must_equal %{[[#<struct PropertyProcessorTest::Song id=1>], [#<struct PropertyProcessorTest::Song id=2>]]}
+	    expect(called.inspect).must_equal %{[[#<struct PropertyProcessorTest::Song id=1>], [#<struct PropertyProcessorTest::Song id=2>]]}
   	end
 
   	it "allows nil collection" do
@@ -39,7 +39,7 @@ class PropertyProcessorTest < Minitest::Spec
 	    called = []
 	    Disposable::Twin::PropertyProcessor.new(twin.class.definitions.get(:songs), twin).() { |v, i| called << [v.model, i] }
 
-	    called.inspect.must_equal %{[]}
+	    expect(called.inspect).must_equal %{[]}
   	end
   end
 end

--- a/test/twin/readable_test.rb
+++ b/test/twin/readable_test.rb
@@ -30,21 +30,21 @@ class ReadableTest < MiniTest::Spec
   let (:twin) { PasswordForm.new(cred) }
 
   it {
-    twin.password.must_be_nil            # not readable.
-    twin.credit_card.name.must_equal "Jonny"
-    twin.credit_card.number.must_be_nil  # not readable.
+    expect(twin.password).must_be_nil            # not readable.
+    expect(twin.credit_card.name).must_equal "Jonny"
+    expect(twin.credit_card.number).must_be_nil  # not readable.
 
     # manual setting on the twin works.
     twin.password = "123"
-    twin.password.must_equal "123"
+    expect(twin.password).must_equal "123"
 
     twin.credit_card.number = "456"
-    twin.credit_card.number.must_equal "456"
+    expect(twin.credit_card.number).must_equal "456"
 
     twin.sync
 
     # it writes, but does not read.
-    cred.inspect.must_equal '#<struct ReadableTest::Credentials password="123", credit_card=#<struct ReadableTest::CreditCard name="Jonny", number="456">>'
+    expect(cred.inspect).must_equal '#<struct ReadableTest::Credentials password="123", credit_card=#<struct ReadableTest::CreditCard name="Jonny", number="456">>'
 
     # test sync{}.
     hash = {}
@@ -52,12 +52,12 @@ class ReadableTest < MiniTest::Spec
       hash = nested
     end
 
-    hash.must_equal("password"=> "123", "credit_card"=>{"name"=>"Jonny", "number"=>"456"})
+    expect(hash).must_equal("password"=> "123", "credit_card"=>{"name"=>"Jonny", "number"=>"456"})
   }
 
   # allow passing non-readable value as option.
   it do
     twin = PasswordForm.new(cred, password: "open sesame!")
-    twin.password.must_equal "open sesame!"
+    expect(twin.password).must_equal "open sesame!"
   end
 end

--- a/test/twin/save_test.rb
+++ b/test/twin/save_test.rb
@@ -48,29 +48,29 @@ class SaveTest < MiniTest::Spec
     twin.save
 
     # sync happened.
-    album.name.must_equal "Live And Dangerous"
-    album.songs[0].must_be_instance_of Model::Song
-    album.songs[1].must_be_instance_of Model::Song
-    album.songs[0].title.must_equal "Southbound"
-    album.songs[1].title.must_equal "The Boys Are Back In Town"
-    album.songs[1].composer.must_be_instance_of Model::Artist
-    album.songs[1].composer.name.must_equal "Lynott"
-    album.artist.must_be_instance_of Model::Artist
-    album.artist.name.must_equal "Thin Lizzy"
+    expect(album.name).must_equal "Live And Dangerous"
+    expect(album.songs[0]).must_be_instance_of Model::Song
+    expect(album.songs[1]).must_be_instance_of Model::Song
+    expect(album.songs[0].title).must_equal "Southbound"
+    expect(album.songs[1].title).must_equal "The Boys Are Back In Town"
+    expect(album.songs[1].composer).must_be_instance_of Model::Artist
+    expect(album.songs[1].composer.name).must_equal "Lynott"
+    expect(album.artist).must_be_instance_of Model::Artist
+    expect(album.artist.name).must_equal "Thin Lizzy"
 
     # saved?
-    album.saved?.must_equal true
-    album.songs[0].saved?.must_equal true
-    album.songs[1].saved?.must_equal true
-    album.songs[1].composer.saved?.must_equal true
-    album.artist.saved?.must_equal true
+    expect(album.saved?).must_equal true
+    expect(album.songs[0].saved?).must_equal true
+    expect(album.songs[1].saved?).must_equal true
+    expect(album.songs[1].composer.saved?).must_equal true
+    expect(album.artist.saved?).must_equal true
   end
 
   #save returns result.
-  it { twin.save.must_equal true }
+  it { expect(twin.save).must_equal true }
   it do
     album.instance_eval { def save; false; end }
-    twin.save.must_equal false
+    expect(twin.save).must_equal false
   end
 
   # with save{}.
@@ -85,22 +85,22 @@ class SaveTest < MiniTest::Spec
       nested_hash = hash
     end
 
-    nested_hash.must_equal({"name"=>"Live And Dangerous", "songs"=>[{"title"=>"Southbound", "composer"=>nil}, {"title"=>"The Boys Are Back In Town", "composer"=>{"name"=>"Lynott"}}], "artist"=>{"name"=>"Thin Lizzy"}})
+    expect(nested_hash).must_equal({"name"=>"Live And Dangerous", "songs"=>[{"title"=>"Southbound", "composer"=>nil}, {"title"=>"The Boys Are Back In Town", "composer"=>{"name"=>"Lynott"}}], "artist"=>{"name"=>"Thin Lizzy"}})
 
     # nothing written to model.
-    album.name.must_be_nil
-    album.songs[0].title.must_be_nil
-    album.songs[1].title.must_be_nil
-    album.songs[1].composer.name.must_be_nil
-    album.artist.name.must_be_nil
+    expect(album.name).must_be_nil
+    expect(album.songs[0].title).must_be_nil
+    expect(album.songs[1].title).must_be_nil
+    expect(album.songs[1].composer.name).must_be_nil
+    expect(album.artist.name).must_be_nil
 
     # nothing saved.
     # saved?
-    album.saved?.must_be_nil
-    album.songs[0].saved?.must_be_nil
-    album.songs[1].saved?.must_be_nil
-    album.songs[1].composer.saved?.must_be_nil
-    album.artist.saved?.must_be_nil
+    expect(album.saved?).must_be_nil
+    expect(album.songs[0].saved?).must_be_nil
+    expect(album.songs[1].saved?).must_be_nil
+    expect(album.songs[1].composer.saved?).must_be_nil
+    expect(album.artist.saved?).must_be_nil
   end
 
 
@@ -136,22 +136,22 @@ class SaveTest < MiniTest::Spec
     twin.save
 
     # sync happened.
-    album.name.must_equal "Live And Dangerous"
-    album.songs[0].must_be_instance_of Model::Song
-    album.songs[1].must_be_instance_of Model::Song
-    album.songs[0].title.must_equal "Southbound"
-    album.songs[1].title.must_equal "The Boys Are Back In Town"
-    album.songs[1].composer.must_be_instance_of Model::Artist
-    album.songs[1].composer.name.must_equal "Lynott"
-    album.artist.must_be_instance_of Model::Artist
-    album.artist.name.must_equal "Thin Lizzy"
+    expect(album.name).must_equal "Live And Dangerous"
+    expect(album.songs[0]).must_be_instance_of Model::Song
+    expect(album.songs[1]).must_be_instance_of Model::Song
+    expect(album.songs[0].title).must_equal "Southbound"
+    expect(album.songs[1].title).must_equal "The Boys Are Back In Town"
+    expect(album.songs[1].composer).must_be_instance_of Model::Artist
+    expect(album.songs[1].composer.name).must_equal "Lynott"
+    expect(album.artist).must_be_instance_of Model::Artist
+    expect(album.artist.name).must_equal "Thin Lizzy"
 
     # saved?
-    album.saved?.must_equal true
-    album.songs[0].saved?.must_be_nil
-    album.songs[1].saved?.must_be_nil
-    album.songs[1].composer.saved?.must_be_nil # doesn't get saved.
-    album.artist.saved?.must_equal true
+    expect(album.saved?).must_equal true
+    expect(album.songs[0].saved?).must_be_nil
+    expect(album.songs[1].saved?).must_be_nil
+    expect(album.songs[1].composer.saved?).must_be_nil # doesn't get saved.
+    expect(album.artist.saved?).must_equal true
   end
 
   def fill_out!(twin)
@@ -185,8 +185,8 @@ end
 #     length_seconds = 120
 #     form.save(length: lambda { |value, options| form.model.id = "#{value}: #{length_seconds}" })
 
-#     song.title.must_equal "A Poor Man's Memory"
-#     song.length.must_be_nil
-#     song.id.must_equal "10: 120"
+#     song.title).must_equal "A Poor Man's Memory"
+#     song.length).must_be_nil
+#     song.id).must_equal "10: 120"
 #   end
 # end

--- a/test/twin/setup_test.rb
+++ b/test/twin/setup_test.rb
@@ -44,16 +44,16 @@ class TwinSetupTest < MiniTest::Spec
     it do
       twin = Twin::Album.new(album)
 
-      twin.songs.size.must_equal 2
-      twin.songs.must_be_instance_of Disposable::Twin::Collection
+      expect(twin.songs.size).must_equal 2
+      expect(twin.songs).must_be_instance_of Disposable::Twin::Collection
 
-      twin.songs[0].must_be_instance_of Twin::Song
-      twin.songs[0].id.must_equal 1
+      expect(twin.songs[0]).must_be_instance_of Twin::Song
+      expect(twin.songs[0].id).must_equal 1
 
-      twin.songs[1].must_be_instance_of Twin::Song
-      twin.songs[1].id.must_equal 1
-      twin.songs[1].composer.must_be_instance_of Twin::Artist
-      twin.songs[1].composer.id.must_equal 2
+      expect(twin.songs[1]).must_be_instance_of Twin::Song
+      expect(twin.songs[1].id).must_equal 1
+      expect(twin.songs[1].composer).must_be_instance_of Twin::Artist
+      expect(twin.songs[1].composer.id).must_equal 2
     end
   end
 
@@ -63,8 +63,8 @@ class TwinSetupTest < MiniTest::Spec
     it do
       twin = Twin::Album.new(album)
 
-      twin.songs.size.must_equal 0
-      twin.songs.must_be_instance_of Disposable::Twin::Collection
+      expect(twin.songs.size).must_equal 0
+      expect(twin.songs).must_be_instance_of Disposable::Twin::Collection
     end
   end
 
@@ -75,7 +75,7 @@ class TwinSetupTest < MiniTest::Spec
   #   it do
   #     twin = Twin::Album.new(album)
 
-  #     twin.songs.size.must_equal 0
+  #     twin.songs.size).must_equal 0
   #     twin.songs.must_be_instance_of Disposable::Twin::Collection
   #   end
   # end
@@ -118,23 +118,23 @@ class TwinSetupWithInlineTwinsTest < MiniTest::Spec
     twin = AlbumForm.new(album)
     # pp twin
 
-    twin.id.must_equal 0
-    twin.name.must_equal "Toto Live"
+    expect(twin.id).must_equal 0
+    expect(twin.name).must_equal "Toto Live"
 
-    twin.artist.must_be_kind_of Disposable::Twin
-    twin.artist.id.must_equal 9
+    expect(twin.artist).must_be_kind_of Disposable::Twin
+    expect(twin.artist.id).must_equal 9
 
-    twin.songs.must_be_instance_of Disposable::Twin::Collection
+    expect(twin.songs).must_be_instance_of Disposable::Twin::Collection
 
     # nil nested objects work (no composer)
-    twin.songs[0].must_be_kind_of Disposable::Twin
-    twin.songs[0].id.must_equal 1
+    expect(twin.songs[0]).must_be_kind_of Disposable::Twin
+    expect(twin.songs[0].id).must_equal 1
 
-    twin.songs[1].must_be_kind_of Disposable::Twin
-    twin.songs[1].id.must_equal 3
+    expect(twin.songs[1]).must_be_kind_of Disposable::Twin
+    expect(twin.songs[1].id).must_equal 3
 
-    twin.songs[1].composer.must_be_kind_of Disposable::Twin
-    twin.songs[1].composer.id.must_equal 2
+    expect(twin.songs[1].composer).must_be_kind_of Disposable::Twin
+    expect(twin.songs[1].composer.id).must_equal 2
   end
 end
 
@@ -149,7 +149,7 @@ class TwinWithVirtualSetupTest < MiniTest::Spec
 
   it do
     twin = AlbumTwin.new(Song.new(1), is_online: true)
-    twin.id.must_equal 1
-    twin.is_online.must_equal true
+    expect(twin.id).must_equal 1
+    expect(twin.is_online).must_equal true
   end
 end

--- a/test/twin/skip_unchanged_test.rb
+++ b/test/twin/skip_unchanged_test.rb
@@ -53,12 +53,12 @@ class SkipUnchangedTest < MiniTest::Spec
     twin.sync
 
     # unchanged, and no exception raised.
-    album.name.must_equal "30 Years Live"
-    song_with_composer.title.must_equal "American Jesus"
-    artist.name.must_equal "Bad Religion"
+    expect(album.name).must_equal "30 Years Live"
+    expect(song_with_composer.title).must_equal "American Jesus"
+    expect(artist.name).must_equal "Bad Religion"
 
     # this actually got synced.
-    song_with_composer.composer.name.must_equal "Greg Graffin" # was nil.
-    song.title.must_equal "Resist Stance" # was nil.
+    expect(song_with_composer.composer.name).must_equal "Greg Graffin" # was nil.
+    expect(song.title).must_equal "Resist Stance" # was nil.
   end
 end

--- a/test/twin/struct/coercion_test.rb
+++ b/test/twin/struct/coercion_test.rb
@@ -21,16 +21,16 @@ class StructCoercionTest < Minitest::Spec
     twin = Expense.new( ExpenseModel.new({}) )
 
     #- direct access, without unnest
-    twin.content.amount.must_be_nil
+    expect(twin.content.amount).must_be_nil
     twin.content.amount = "1.8"
-    twin.content.amount.must_equal 1.8
+    expect(twin.content.amount).must_equal 1.8
   end
 
   it "via unnest" do
     twin = Expense.new( ExpenseModel.new({}) )
 
-    twin.amount.must_be_nil
+    expect(twin.amount).must_be_nil
     twin.amount = "1.8"
-    twin.amount.must_equal 1.8
+    expect(twin.amount).must_equal 1.8
   end
 end

--- a/test/twin/struct_test.rb
+++ b/test/twin/struct_test.rb
@@ -11,19 +11,19 @@ class TwinStructTest < MiniTest::Spec
   end
 
   # empty hash
-  # it { Song.new({}).number.must_equal 1 }
-  it { Song.new({}).number.must_be_nil } # TODO: implement default.
+  # it { Song.new({}).number).must_equal 1 }
+  it { expect(Song.new({}).number).must_be_nil } # TODO: implement default.
 
   # model hash
-  it { Song.new(number: 2).number.must_equal 2 }
+  it { expect(Song.new(number: 2).number).must_equal 2 }
 
   # with hash and options as one hash.
-  it { Song.new(number: 3, cool?: true).cool?.must_equal true }
-  it { Song.new(number: 3, cool?: true).number.must_equal 3 }
+  it { expect(Song.new(number: 3, cool?: true).cool?).must_equal true }
+  it { expect(Song.new(number: 3, cool?: true).number).must_equal 3 }
 
   # with model hash and options hash separated.
-  it { Song.new({number: 3}, {cool?: true}).cool?.must_equal true }
-  it { Song.new({number: 3}, {cool?: true}).number.must_equal 3 }
+  it { expect(Song.new({number: 3}, {cool?: true}).cool?).must_equal true }
+  it { expect(Song.new({number: 3}, {cool?: true}).number).must_equal 3 }
 
 
   describe "writing" do
@@ -33,8 +33,8 @@ class TwinStructTest < MiniTest::Spec
     # writer
     it do
       song.number = 9
-      song.number.must_equal 9
-      model[:number].must_equal 3
+      expect(song.number).must_equal 9
+      expect(model[:number]).must_equal 3
     end
 
     # writer with sync
@@ -42,10 +42,10 @@ class TwinStructTest < MiniTest::Spec
       song.number = 9
       model = song.sync
 
-      song.number.must_equal 9
-      model["number"].must_equal 9
+      expect(song.number).must_equal 9
+      expect(model["number"]).must_equal 9
 
-      # song.send(:model).object_id.must_equal model.object_id
+      # song.send(:model).object_id).must_equal model.object_id
     end
   end
 end
@@ -79,26 +79,26 @@ class TwinWithNestedStructTest < MiniTest::Spec
     preferences: {show_image: true, play_teaser: 2}, roles: [{name: "user"}]}) }
 
   # public "hash" reader
-  it { Song.new(model).options.recorded.must_equal true }
+  it { expect(Song.new(model).options.recorded).must_equal true }
 
   # public "hash" writer
   it {
     song = Song.new(model)
 
     song.options.recorded = "yo"
-    song.options.recorded.must_equal "yo"
+    expect(song.options.recorded).must_equal "yo"
 
-    song.options.preferences.show_image.must_equal true
-    song.options.preferences.play_teaser.must_equal 2
+    expect(song.options.preferences.show_image).must_equal true
+    expect(song.options.preferences.play_teaser).must_equal 2
 
     song.options.preferences.show_image= 9
 
 
     song.sync # this is only called on the top model, e.g. in Reform#save.
 
-    model.title.must_equal "Seed of Fear and Anger"
-    model.options["recorded"].must_equal "yo"
-    model.options["preferences"].must_equal({"show_image" => 9, "play_teaser"=>2})
+    expect(model.title).must_equal "Seed of Fear and Anger"
+    expect(model.options["recorded"]).must_equal "yo"
+    expect(model.options["preferences"]).must_equal({"show_image" => 9, "play_teaser"=>2})
   }
 
   describe "nested writes" do
@@ -111,14 +111,14 @@ class TwinWithNestedStructTest < MiniTest::Spec
       role = song.options.roles.append({}) # add empty "model" to hash collection.
       role.name = "admin"
 
-      song.options.roles.size.must_equal 2
-      song.options.roles[0].name.must_equal "user"
-      song.options.roles[1].name.must_equal "admin"
-      model.options[:roles].must_equal([{:name=>"user"}]) # model hasn't changed, of course.
+      expect(song.options.roles.size).must_equal 2
+      expect(song.options.roles[0].name).must_equal "user"
+      expect(song.options.roles[1].name).must_equal "admin"
+      expect(model.options[:roles]).must_equal([{:name=>"user"}]) # model hasn't changed, of course.
 
       song.sync
 
-      model.options.must_equal({"recorded"=>true, "released"=>1, "preferences"=>{"show_image"=>true, "play_teaser"=>2}, "roles"=>[{"name"=>"user"}, {"name"=>"admin"}]})
+      expect(model.options).must_equal({"recorded"=>true, "released"=>1, "preferences"=>{"show_image"=>true, "play_teaser"=>2}, "roles"=>[{"name"=>"user"}, {"name"=>"admin"}]})
     end
 
     # overwriting nested property via #preferences=.
@@ -126,7 +126,7 @@ class TwinWithNestedStructTest < MiniTest::Spec
       song.options.preferences = {play_teaser: :maybe}
       song.sync
 
-      model.options.must_equal({"recorded"=>true, "released"=>1, "preferences"=>{"play_teaser"=>:maybe}, "roles"=>[{"name"=>"user"}]})
+      expect(model.options).must_equal({"recorded"=>true, "released"=>1, "preferences"=>{"play_teaser"=>:maybe}, "roles"=>[{"name"=>"user"}]})
     end
 
     # overwriting collection via #roles=.
@@ -134,7 +134,7 @@ class TwinWithNestedStructTest < MiniTest::Spec
       song.options.roles = [{name: "wizard"}]
       song.sync
 
-      model.options.must_equal({"recorded"=>true, "released"=>1, "preferences"=>{"show_image"=>true, "play_teaser"=>2}, "roles"=>[{"name"=>"wizard"}]})
+      expect(model.options).must_equal({"recorded"=>true, "released"=>1, "preferences"=>{"show_image"=>true, "play_teaser"=>2}, "roles"=>[{"name"=>"wizard"}]})
     end
   end
 
@@ -146,7 +146,7 @@ class TwinWithNestedStructTest < MiniTest::Spec
 
   #   song.sync
 
-  #   model[:options][:roles].must_equal({    })
+  #   model[:options][:roles]).must_equal({    })
 
   #   pp song
 
@@ -178,8 +178,8 @@ class StructReadableWriteableTest < Minitest::Spec
 
   it "ignores readable: false" do
     song = Song.new(length: 123, id: 1)
-    song.length.must_equal 123
-    song.id.must_be_nil
+    expect(song.length).must_equal 123
+    expect(song.id).must_be_nil
   end
 
   it "ignores writeable: false" do
@@ -209,20 +209,20 @@ class DefaultWithStructTest < Minitest::Spec
   # all given.
   it do
     twin = Twin.new(Song.new({enabled: true, roles: {admin: false}}))
-    twin.settings.enabled.must_equal true
-    twin.settings.roles.admin.must_equal false
+    expect(twin.settings.enabled).must_equal true
+    expect(twin.settings.roles.admin).must_equal false
   end
 
   # defaults, please.
   it do
     song = Song.new
     twin = Twin.new(song)
-    twin.settings.enabled.must_equal "yes"
-    twin.settings.roles.admin.must_equal "maybe"
+    expect(twin.settings.enabled).must_equal "yes"
+    expect(twin.settings.roles.admin).must_equal "maybe"
 
     twin.sync
 
-    song.settings.must_equal({"enabled"=>"yes", "roles"=>{"admin"=>"maybe"}})
+    expect(song.settings).must_equal({"enabled"=>"yes", "roles"=>{"admin"=>"maybe"}})
   end
 end
 
@@ -258,7 +258,7 @@ class CompositionWithStructTest < Minitest::Spec
 
     twin.sync
 
-    model.content.must_equal({"tags"=>["history"], "notes"=>[{"text"=>"Freedom", "index"=>0}, {"text"=>"Like", "index"=>1}, {"text"=>"Canberra trip", "index"=>2}]})
+    expect(model.content).must_equal({"tags"=>["history"], "notes"=>[{"text"=>"Freedom", "index"=>0}, {"text"=>"Like", "index"=>1}, {"text"=>"Canberra trip", "index"=>2}]})
   end
 
   class Sheet < Disposable::Twin
@@ -319,9 +319,9 @@ class CompositionWithStructTest < Minitest::Spec
 
 
 
-    sheet.tags.must_equal "#hashtag"
-    sheet.notes[0].text.must_equal "Freedom"
-    sheet.notes[0].index.must_equal 0
+    expect(sheet.tags).must_equal "#hashtag"
+    expect(sheet.notes[0].text).must_equal "Freedom"
+    expect(sheet.notes[0].index).must_equal 0
 
     sheet.notes[0].index = 2
 

--- a/test/twin/sync_test.rb
+++ b/test/twin/sync_test.rb
@@ -47,23 +47,23 @@ class TwinSyncTest < MiniTest::Spec
       fill_out!(twin)
 
       # not written to model, yet.
-      album.name.must_be_nil
-      album.songs[0].title.must_be_nil
-      album.songs[1].title.must_be_nil
-      album.songs[1].composer.name.must_be_nil
-      album.artist.name.must_be_nil
+      expect(album.name).must_be_nil
+      expect(album.songs[0].title).must_be_nil
+      expect(album.songs[1].title).must_be_nil
+      expect(album.songs[1].composer.name).must_be_nil
+      expect(album.artist.name).must_be_nil
 
       twin.sync
 
-      album.name.must_equal "Live And Dangerous"
-      album.songs[0].must_be_instance_of Model::Song
-      album.songs[1].must_be_instance_of Model::Song
-      album.songs[0].title.must_equal "Southbound"
-      album.songs[1].title.must_equal "The Boys Are Back In Town"
-      album.songs[1].composer.must_be_instance_of Model::Artist
-      album.songs[1].composer.name.must_equal "Lynott"
-      album.artist.must_be_instance_of Model::Artist
-      album.artist.name.must_equal "Thin Lizzy"
+      expect(album.name).must_equal "Live And Dangerous"
+      expect(album.songs[0]).must_be_instance_of Model::Song
+      expect(album.songs[1]).must_be_instance_of Model::Song
+      expect(album.songs[0].title).must_equal "Southbound"
+      expect(album.songs[1].title).must_equal "The Boys Are Back In Town"
+      expect(album.songs[1].composer).must_be_instance_of Model::Artist
+      expect(album.songs[1].composer.name).must_equal "Lynott"
+      expect(album.artist).must_be_instance_of Model::Artist
+      expect(album.artist.name).must_equal "Thin Lizzy"
     end
 
     # with empty, not populated model.
@@ -82,16 +82,16 @@ class TwinSyncTest < MiniTest::Spec
       twin.songs[1].composer.name = "Lynott"
 
       # not written to model, yet.
-      album.name.must_be_nil
-      album.songs.must_equal []
-      album.artist.must_be_nil
+      expect(album.name).must_be_nil
+      expect(album.songs).must_equal []
+      expect(album.artist).must_be_nil
 
       twin.sync # this assigns a new collection via #songs=.
 
-      album.name.must_equal "Live And Dangerous"
-      album.songs[0].title.must_equal "Southbound"
-      album.songs[1].title.must_equal "The Boys Are Back In Town"
-      album.songs[1].composer.name.must_equal "Lynott"
+      expect(album.name).must_equal "Live And Dangerous"
+      expect(album.songs[0].title).must_equal "Southbound"
+      expect(album.songs[1].title).must_equal "The Boys Are Back In Town"
+      expect(album.songs[1].composer.name).must_equal "Lynott"
     end
 
     # save with block.
@@ -107,14 +107,14 @@ class TwinSyncTest < MiniTest::Spec
           nested_hash = hash
         end
 
-        nested_hash.must_equal({"name"=>"Live And Dangerous", "songs"=>[{"title"=>"Southbound", "composer"=>nil}, {"title"=>"The Boys Are Back In Town", "composer"=>{"name"=>"Lynott"}}], "artist"=>{"name"=>"Thin Lizzy"}})
+        expect(nested_hash).must_equal({"name"=>"Live And Dangerous", "songs"=>[{"title"=>"Southbound", "composer"=>nil}, {"title"=>"The Boys Are Back In Town", "composer"=>{"name"=>"Lynott"}}], "artist"=>{"name"=>"Thin Lizzy"}})
 
         # nothing written to model.
-        album.name.must_be_nil
-        album.songs[0].title.must_be_nil
-        album.songs[1].title.must_be_nil
-        album.songs[1].composer.name.must_be_nil
-        album.artist.name.must_be_nil
+        expect(album.name).must_be_nil
+        expect(album.songs[0].title).must_be_nil
+        expect(album.songs[1].title).must_be_nil
+        expect(album.songs[1].composer.name).must_be_nil
+        expect(album.artist.name).must_be_nil
       end
 
       describe "nil values" do
@@ -127,7 +127,7 @@ class TwinSyncTest < MiniTest::Spec
           nested_hash = nil
           twin.sync { |hash| nested_hash = hash }
 
-          nested_hash.must_equal({"name"=>nil, "artist"=>nil})
+          expect(nested_hash).must_equal({"name"=>nil, "artist"=>nil})
         end
 
         it "includes empty collections" do
@@ -139,7 +139,7 @@ class TwinSyncTest < MiniTest::Spec
           nested_hash = nil
           twin.sync { |hash| nested_hash = hash }
 
-          nested_hash.must_equal({"name"=>nil, "songs"=>[], "artist"=>nil})
+          expect(nested_hash).must_equal({"name"=>nil, "songs"=>[], "artist"=>nil})
         end
       end
     end

--- a/test/twin/twin_test.rb
+++ b/test/twin/twin_test.rb
@@ -35,17 +35,17 @@ class TwinTest < MiniTest::Spec
       twin = Twin::Song.new(song)
       song.id = 2
       # :from maps public name
-      twin.title.must_equal "Broken" # public: #record_name
-      twin.id.must_equal 1
+      expect(twin.title).must_equal "Broken" # public: #record_name
+      expect(twin.id).must_equal 1
     end
 
     # allows passing options.
     it do
       # override twin's value...
-      Twin::Song.new(song, :title => "Kenny").title.must_equal "Kenny"
+      expect(Twin::Song.new(song, :title => "Kenny").title).must_equal "Kenny"
 
       # .. but do not write to the model!
-      song.title.must_equal "Broken"
+      expect(song.title).must_equal "Broken"
     end
   end
 
@@ -59,28 +59,28 @@ class TwinTest < MiniTest::Spec
       twin.album = album # this is a model, not a twin.
 
       # updates twin
-      twin.id.must_equal 3
-      twin.title.must_equal "Lucky"
+      expect(twin.id).must_equal 3
+      expect(twin.title).must_equal "Lucky"
 
       # setter for nested property will twin value.
       twin.album.extend(Disposable::Comparable)
-      assert twin.album == Twin::Album.new(album) # FIXME: why does must_equal not call #== ?
+      assert twin.album == Twin::Album.new(album) # FIXME: why does) must_equal not call #== ?
 
       # setter for nested collection.
 
       # DOES NOT update model
-      song.id.must_equal 1
-      song.title.must_equal "Broken"
+      expect(song.id).must_equal 1
+      expect(song.title).must_equal "Broken"
     end
 
     describe "deleting" do
       it "allows overwriting nested twin with nil" do
         album = Model::Album.new(1, "Uncertain Terms", [], Model::Artist.new("Greg Howe"))
         twin = Twin::Album.new(album)
-        twin.artist.id.must_equal "Greg Howe"
+        expect(twin.artist.id).must_equal "Greg Howe"
 
         twin.artist = nil
-        twin.artist.must_be_nil
+        expect(twin.artist).must_be_nil
       end
     end
 
@@ -109,8 +109,8 @@ class OverridingAccessorsTest < TwinTest
   end
 
   let (:model) { Model::Song.new(1, "A Tale That Wasn't Right") }
-  it { Song.new(model).title.must_equal "a tale that wasn't right" }
-  it { Song.new(model).id.must_equal 2 }
+  it { expect(Song.new(model).title).must_equal "a tale that wasn't right" }
+  it { expect(Song.new(model).id).must_equal 2 }
 end
 
 
@@ -148,7 +148,7 @@ class AccessorsTest < Minitest::Spec
 
   it do
     twin = Twin.new(Song.new("bla"))
-    twin.format.must_equal "bla"
+    expect(twin.format).must_equal "bla"
     twin.format = "blubb"
   end
 end

--- a/test/twin/unnest_test.rb
+++ b/test/twin/unnest_test.rb
@@ -16,22 +16,22 @@ class UnnestTest < MiniTest::Spec
   end
 
   it "copies property option" do
-    Twin.definitions.get(:id).extend(Declarative::Inspect).inspect.must_equal %{#<Disposable::Twin::Definition: @options={:nice=>\"yes\", :private_name=>:id, :name=>\"id\", :readable=>false, :writeable=>false}>}
-    Twin.definitions.get(:ids).extend(Declarative::Inspect).inspect.must_equal %{#<Disposable::Twin::Definition: @options={:status=>\"healthy\", :collection=>true, :private_name=>:ids, :name=>\"ids\", :readable=>false, :writeable=>false}>}
+    expect(Twin.definitions.get(:id).extend(Declarative::Inspect).inspect).must_equal %{#<Disposable::Twin::Definition: @options={:nice=>\"yes\", :private_name=>:id, :name=>\"id\", :readable=>false, :writeable=>false}>}
+    expect(Twin.definitions.get(:ids).extend(Declarative::Inspect).inspect).must_equal %{#<Disposable::Twin::Definition: @options={:status=>\"healthy\", :collection=>true, :private_name=>:ids, :name=>\"ids\", :readable=>false, :writeable=>false}>}
     # also copies :nested.
-    Twin.definitions.get(:email).extend(Declarative::Inspect).inspect.must_equal %{#<Disposable::Twin::Definition: @options={:private_name=>:email, :nested=>#<Class:>, :name=>\"email\", :readable=>false, :writeable=>false}>}
+    expect(Twin.definitions.get(:email).extend(Declarative::Inspect).inspect).must_equal %{#<Disposable::Twin::Definition: @options={:private_name=>:email, :nested=>#<Class:>, :name=>\"email\", :readable=>false, :writeable=>false}>}
   end
 
   it "exposes accessors on top-level twin" do
     twin = Twin.new(OpenStruct.new(content: OpenStruct.new()))
 
-    twin.email.must_be_nil
+    expect(twin.email).must_be_nil
     twin.email= 2
-    twin.email.model.must_equal 2
+    expect(twin.email.model).must_equal 2
 
 
-    twin.id.must_be_nil
+    expect(twin.id).must_be_nil
     twin.id = 1
-    twin.id.must_equal 1
+    expect(twin.id).must_equal 1
   end
 end

--- a/test/twin/virtual_test.rb
+++ b/test/twin/virtual_test.rb
@@ -11,7 +11,7 @@ class VirtualTest < MiniTest::Spec
   it {
     twin.credit_card_number = "123"
 
-    twin.credit_card_number.must_equal "123"  # this is still readable in the UI.
+    expect(twin.credit_card_number).must_equal "123"  # this is still readable in the UI.
 
     twin.sync
 
@@ -20,7 +20,7 @@ class VirtualTest < MiniTest::Spec
       hash = nested
     end
 
-    hash.must_equal("credit_card_number"=> "123")
+    expect(hash).must_equal("credit_card_number"=> "123")
   }
 
   describe "setter should never be called with virtual:true" do
@@ -33,7 +33,7 @@ class VirtualTest < MiniTest::Spec
     end
 
     it "what" do
-      Raising.new(Object.new).id.must_be_nil
+      expect(Raising.new(Object.new).id).must_be_nil
     end
   end
 end

--- a/test/twin/writeable_test.rb
+++ b/test/twin/writeable_test.rb
@@ -30,20 +30,20 @@ class WriteableTest < MiniTest::Spec
   let (:twin) { PasswordForm.new(cred) }
 
   it {
-    twin.password.must_equal "secret"
-    twin.credit_card.name.must_equal "Jonny"
-    twin.credit_card.number.must_equal "0987654321"
+    expect(twin.password).must_equal "secret"
+    expect(twin.credit_card.name).must_equal "Jonny"
+    expect(twin.credit_card.number).must_equal "0987654321"
 
     # manual setting on the twin works.
     twin.password = "123"
-    twin.password.must_equal "123"
+    expect(twin.password).must_equal "123"
 
     twin.credit_card.number = "456"
-    twin.credit_card.number.must_equal "456"
+    expect(twin.credit_card.number).must_equal "456"
 
     twin.sync
 
-    cred.inspect.must_equal '#<struct WriteableTest::Credentials password="secret", credit_card=#<struct WriteableTest::CreditCard name="Jonny", number="0987654321">>'
+    expect(cred.inspect).must_equal '#<struct WriteableTest::Credentials password="secret", credit_card=#<struct WriteableTest::CreditCard name="Jonny", number="0987654321">>'
 
     # test sync{}.
     hash = {}
@@ -51,6 +51,6 @@ class WriteableTest < MiniTest::Spec
       hash = nested
     end
 
-    hash.must_equal("password"=> "123", "credit_card"=>{"name"=>"Jonny", "number"=>"456"})
+    expect(hash).must_equal("password"=> "123", "credit_card"=>{"name"=>"Jonny", "number"=>"456"})
   }
 end


### PR DESCRIPTION
New versions of dry-types raise a coercion error when passing the wrong type which is really different than how it was done before so deprecating `nilify` feels the correct thing to do and force uses to pass `type` and deal with dry-types directly.