### PR TITLE
Add `Struct#persisted?`

### DIFF
--- a/lib/disposable/twin/property/struct.rb
+++ b/lib/disposable/twin/property/struct.rb
@@ -29,6 +29,9 @@ class Disposable::Twin
       # So far, hashes can't be persisted separately.
       def save!
       end
+
+      def persisted?
+      end
     end
   end # Property
 end

--- a/test/twin/struct_test.rb
+++ b/test/twin/struct_test.rb
@@ -170,6 +170,11 @@ class TwinWithNestedStructTest < MiniTest::Spec
   describe "#save" do
     it { Song.new(model).extend(Disposable::Twin::Save).save }
   end
+
+  describe "#persisted?" do
+    it { expect(Song.new(model).options.persisted?).must_be_nil }
+    it { expect(Song.new(model).options.preferences.persisted?).must_be_nil }
+  end
 end
 
 class StructReadableWriteableTest < Minitest::Spec


### PR DESCRIPTION
As `Struct` can respond to `save!`, it should respond to
`persisted?` too.

Scenario - `reform-rails` [forwards](https://github.com/trailblazer/reform-rails/blob/master/lib/reform/form/active_model.rb#L10) persistence call to `Struct` twin, assuming the `model` is an activemodel instance (Though, it also forwards calls for `:id` & `:to_key` which are not specific to `Struct` 🤔 ).