### PR TITLE
Loosen Representable dependency to allow versions < 4

### DIFF
--- a/disposable.gemspec
+++ b/disposable.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "declarative",         ">= 0.0.9", "< 1.0.0"
   # spec.add_dependency "declarative-builder"  #, ">= 0.2.0"
-  spec.add_dependency "representable",       ">= 3.1.1", "< 3.2.0"
+  spec.add_dependency "representable",       ">= 3.1.1", "< 4"
 
   spec.add_development_dependency "bundler"#, "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This allows us to use representable 3.2.0 and other new minor versions.