### PR TITLE
Add Ruby 3.1 and Rails 7.0 to the CI matrix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,13 @@ jobs:
           - ruby: '3.0'
             active_record: 6.1
             dry_types: 1.5
+          - ruby: 3.1 
+            active_record: 7.0.1
+            dry_types: 1.5
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
This PR adds Ruby 3.1 and Rails 7.0 to the CI matrix.  It was necessary to use the string `7.0.1` for the`active_record` value because Rails 7.0.0 has a compatibility bug with Ruby 3.1.

Updated the checkout action and also added a dependabot file to keep GitHub Actions up-to-date.

Runs green on my fork.