### PR TITLE
Avoid throwing an exception for failed coercions with dry-types 1.x

### DIFF
--- a/lib/disposable/twin/coercion.rb
+++ b/lib/disposable/twin/coercion.rb
@@ -25,7 +25,7 @@ module Disposable::Twin::Coercion
 
       mod = Module.new do
         define_method("#{name}=") do |value|
-          super type.(value)
+          super type.(value) { value }
         end
       end
       include mod


### PR DESCRIPTION
dry-types 0.15 and 1.x changed how failed coercions are reported. Older versions returned the original value while newer versions raise an exception.

0.14.1:

```ruby
Types::Params::Integer['cow']
 # => "cow"
```

1.7.1:

```ruby
Types::Params::Integer['cow']
 # *** Dry::Types::CoercionError Exception: invalid value for Integer(): "cow"
```

Fortunately, the constructor accepts an optional block:

> When a block is passed, `{#call}` will never throw an exception on
> failed coercion, instead it will call the block.

Doubly-fortunately, the block appears to be ignored on older versions of dry-types.

To preserve the current behavior, we update to use a block that returns the original value.