### PR TITLE
Add ostruct as dependency to gemspec

### DIFF
--- a/disposable.gemspec
+++ b/disposable.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "declarative",         ">= 0.0.9", "< 1.0.0"
   # spec.add_dependency "declarative-builder"  #, ">= 0.2.0"
   spec.add_dependency "representable",       ">= 3.1.1", "< 4"
+  spec.add_dependency "ostruct",             "< 1"
 
   spec.add_development_dependency "bundler"#, "~> 1.3"
   spec.add_development_dependency "rake"

--- a/test/api_semantics_test.rb
+++ b/test/api_semantics_test.rb
@@ -136,7 +136,7 @@
 
 
 
-# class ApiSemanticsTest < MiniTest::Spec
+# class ApiSemanticsTest < Minitest::Spec
 #   it "xxx" do
 #     album = Model::Album.new(1, "And So I Watch You From Afar", [Model::Song.new(2, "Solidarity"), Model::Song.new(0, "Tale That Wasn't Right")])
 
@@ -153,7 +153,7 @@
 
 # end
 
-# class RemoveFlagSetButNotEnabled < MiniTest::Spec
+# class RemoveFlagSetButNotEnabled < Minitest::Spec
 #   class AlbumDecorator < Representable::Decorator
 #     include Representable::Hash
 
@@ -183,7 +183,7 @@
 #   end
 # end
 
-# class UserCallableTest < MiniTest::Spec
+# class UserCallableTest < Minitest::Spec
 #   class MyOwnSemantic < Representable::Semantics::Semantic
 #     def self.call(model, fragment, index, options)
 #       if fragment["title"] =~ /Solidarity/
@@ -220,7 +220,7 @@
 # end
 
 
-# class ApiSemanticsWithUpdate < MiniTest::Spec
+# class ApiSemanticsWithUpdate < Minitest::Spec
 #   class AlbumDecorator < Representable::Decorator
 #     include Representable::Hash
 

--- a/test/callback_group_test.rb
+++ b/test/callback_group_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "disposable/callback"
 
-class CallbackGroupTest < MiniTest::Spec
+class CallbackGroupTest < Minitest::Spec
   class Group < Disposable::Callback::Group
     attr_reader :output
 
@@ -143,7 +143,7 @@ class CallbackGroupTest < MiniTest::Spec
 end
 
 
-class CallbackGroupInheritanceTest < MiniTest::Spec
+class CallbackGroupInheritanceTest < Minitest::Spec
   class Group < Disposable::Callback::Group
     on_change :change!
     collection :songs do

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "disposable/callback"
 
-class CallbacksTest < MiniTest::Spec
+class CallbacksTest < Minitest::Spec
   before do
     @invokes = []
   end

--- a/test/expose_test.rb
+++ b/test/expose_test.rb
@@ -3,7 +3,7 @@ require "disposable/expose"
 require "disposable/composition"
 
 # Disposable::Expose.
-class ExposeTest < MiniTest::Spec
+class ExposeTest < Minitest::Spec
   module Model
     Album = Struct.new(:id, :name)
   end
@@ -45,7 +45,7 @@ end
 
 
 # Disposable::Composition.
-class ExposeCompositionTest < MiniTest::Spec
+class ExposeCompositionTest < Minitest::Spec
   module Model
     Band  = Struct.new(:id)
     Album = Struct.new(:id, :name)

--- a/test/persisted_test.rb
+++ b/test/persisted_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PersistedTest < MiniTest::Spec
+class PersistedTest < Minitest::Spec
   class AlbumTwin < Disposable::Twin
     feature Sync, Save
     feature Persisted, Changed

--- a/test/rescheme_test.rb
+++ b/test/rescheme_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ReschemeTest < MiniTest::Spec
+class ReschemeTest < Minitest::Spec
   module Representer
     include Representable
 
@@ -128,7 +128,7 @@ class ReschemeTest < MiniTest::Spec
 end
 
 
-class TwinReschemeTest < MiniTest::Spec
+class TwinReschemeTest < Minitest::Spec
   class Artist < Disposable::Twin
     property :name
   end

--- a/test/skip_getter_test.rb
+++ b/test/skip_getter_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class SkipGetterTest < MiniTest::Spec
+class SkipGetterTest < Minitest::Spec
   Album  = Struct.new(:title, :artist)
   Artist = Struct.new(:name)
 
@@ -44,7 +44,7 @@ class SkipGetterTest < MiniTest::Spec
 end
 
 
-class SkipSetterTest < MiniTest::Spec
+class SkipSetterTest < Minitest::Spec
   Album  = Struct.new(:title, :artist)
   Artist = Struct.new(:name)
 
@@ -74,7 +74,7 @@ class SkipSetterTest < MiniTest::Spec
 end
 
 
-class SkipGetterAndSetterWithChangedTest < MiniTest::Spec
+class SkipGetterAndSetterWithChangedTest < Minitest::Spec
   Album  = Struct.new(:title, :artist)
   Artist = Struct.new(:name)
 

--- a/test/twin/builder_test.rb
+++ b/test/twin/builder_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 require "disposable/twin/builder"
 
-class BuilderTest < MiniTest::Spec
+class BuilderTest < Minitest::Spec
   module Model
     Song = Struct.new(:id, :title)
     Hit = Struct.new(:id, :title)

--- a/test/twin/changed_test.rb
+++ b/test/twin/changed_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 # require 'reform/form/coercion'
 
-class ChangedWithSetupTest < MiniTest::Spec
+class ChangedWithSetupTest < Minitest::Spec
   module Model
     Song  = Struct.new(:title, :length, :composer)
     Album = Struct.new(:name, :songs, :artist)
@@ -107,7 +107,7 @@ end
 
 
 require "disposable/twin/coercion"
-class ChangedWithCoercionTest < MiniTest::Spec
+class ChangedWithCoercionTest < Minitest::Spec
   Song = Struct.new(:released)
 
   class SongTwin < Disposable::Twin

--- a/test/twin/coercion_test.rb
+++ b/test/twin/coercion_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 require "disposable/twin/coercion"
 
-class CoercionTest < MiniTest::Spec
+class CoercionTest < Minitest::Spec
   class TwinWithSkipSetter < Disposable::Twin
     feature Coercion
     feature Setup::SkipSetter
@@ -156,7 +156,7 @@ end
 # this converts "" to nil and then breaks because it's strict.
 # Types::Strict::String.constructor(Dry::Types::Params.method(:to_nil))
 
-class CoercionTypingTest < MiniTest::Spec
+class CoercionTypingTest < Minitest::Spec
   class Song < Disposable::Twin
     include Coercion
     include Setup::SkipSetter

--- a/test/twin/collection_test.rb
+++ b/test/twin/collection_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 
 # TODO: eg "after delete hook (dynamic_delete)", after_add
 
-class TwinCollectionTest < MiniTest::Spec
+class TwinCollectionTest < Minitest::Spec
   module Model
     Song  = Struct.new(:id, :title, :album)
     Album = Struct.new(:id, :name, :songs, :artist)
@@ -54,7 +54,7 @@ end
 require "disposable/twin/sync"
 require "disposable/twin/save"
 
-class TwinCollectionActiveRecordTest < MiniTest::Spec
+class TwinCollectionActiveRecordTest < Minitest::Spec
   module Twin
     class Song < Disposable::Twin
       property :id # DISCUSS: needed for #save.
@@ -204,7 +204,7 @@ class TwinCollectionActiveRecordTest < MiniTest::Spec
 end
 
 
-class CollectionUnitTest < MiniTest::Spec
+class CollectionUnitTest < Minitest::Spec
   module Twin
     class Album < Disposable::Twin
     end

--- a/test/twin/composition_test.rb
+++ b/test/twin/composition_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # Disposable::Twin::Composition.
-class TwinCompositionTest < MiniTest::Spec
+class TwinCompositionTest < Minitest::Spec
   class Request < Disposable::Twin
     include Sync
     include Save

--- a/test/twin/expose_test.rb
+++ b/test/twin/expose_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # Disposable::Twin::Expose.
-class TwinExposeTest < MiniTest::Spec
+class TwinExposeTest < Minitest::Spec
   class Request < Disposable::Twin
     feature Sync
     feature Save

--- a/test/twin/feature_test.rb
+++ b/test/twin/feature_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class FeatureTest < MiniTest::Spec
+class FeatureTest < Minitest::Spec
   Song  = Struct.new(:title, :album, :composer)
   Album = Struct.new(:name, :songs, :artist)
   Artist = Struct.new(:name)

--- a/test/twin/from_collection_test.rb
+++ b/test/twin/from_collection_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TwinFromCollectionDecoratorTest < MiniTest::Spec
+class TwinFromCollectionDecoratorTest < Minitest::Spec
   module Model
     Artist = Struct.new(:id, :name)
   end

--- a/test/twin/from_test.rb
+++ b/test/twin/from_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class FromTest < MiniTest::Spec
+class FromTest < Minitest::Spec
   module Model
     Album = Struct.new(:name, :composer)
     Artist = Struct.new(:realname)

--- a/test/twin/hash_test.rb
+++ b/test/twin/hash_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "disposable/twin/property/hash"
 
-class HashTest < MiniTest::Spec
+class HashTest < Minitest::Spec
   Model = Struct.new(:id, :content)
 
   class Song < Disposable::Twin

--- a/test/twin/inherit_test.rb
+++ b/test/twin/inherit_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class InheritTest < MiniTest::Spec
+class InheritTest < Minitest::Spec
   module Model
     Song  = Struct.new(:title, :album)
     Album = Struct.new(:name, :songs, :artist)

--- a/test/twin/parent_test.rb
+++ b/test/twin/parent_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "disposable/twin/parent.rb"
 
-class TwinParentTest < MiniTest::Spec
+class TwinParentTest < Minitest::Spec
   module Model
     Album = Struct.new(:id, :artist, :songs)
     Artist = Struct.new(:name)

--- a/test/twin/process_inline_test.rb
+++ b/test/twin/process_inline_test.rb
@@ -1,6 +1,6 @@
 # require "test_helper"
 
-# class ProcessInlineTest < MiniTest::Spec
+# class ProcessInlineTest < Minitest::Spec
 #   Album = Struct.new(:artist, :composer, :recursive_composer)
 
 #   module InlineTwin

--- a/test/twin/readable_test.rb
+++ b/test/twin/readable_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ReadableTest < MiniTest::Spec
+class ReadableTest < Minitest::Spec
   Credentials = Struct.new(:password, :credit_card) do
     def password
       raise "don't call me!"

--- a/test/twin/save_test.rb
+++ b/test/twin/save_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SaveTest < MiniTest::Spec
+class SaveTest < Minitest::Spec
   module Model
     Song  = Struct.new(:title, :composer)
     Album = Struct.new(:name, :songs, :artist)
@@ -166,7 +166,7 @@ end
 
 # TODO: with block
 
-# class SaveWithDynamicOptionsTest < MiniTest::Spec
+# class SaveWithDynamicOptionsTest < Minitest::Spec
 #   Song = Struct.new(:id, :title, :length) do
 #     include Disposable::Saveable
 #   end

--- a/test/twin/setup_test.rb
+++ b/test/twin/setup_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class TwinSetupTest < MiniTest::Spec
+class TwinSetupTest < Minitest::Spec
   module Model
     Song  = Struct.new(:id, :title, :album, :composer)
     Album = Struct.new(:id, :name, :songs, :artist)
@@ -82,7 +82,7 @@ class TwinSetupTest < MiniTest::Spec
 end
 
 # test inline twin building and setup.
-class TwinSetupWithInlineTwinsTest < MiniTest::Spec
+class TwinSetupWithInlineTwinsTest < Minitest::Spec
   module Model
     Song  = Struct.new(:id, :composer)
     Album = Struct.new(:id, :name, :songs, :artist)
@@ -139,7 +139,7 @@ class TwinSetupWithInlineTwinsTest < MiniTest::Spec
 end
 
 # Twin.new(model, is_online: true)
-class TwinWithVirtualSetupTest < MiniTest::Spec
+class TwinWithVirtualSetupTest < Minitest::Spec
   Song = Struct.new(:id)
 
   class AlbumTwin < Disposable::Twin

--- a/test/twin/skip_unchanged_test.rb
+++ b/test/twin/skip_unchanged_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class SkipUnchangedTest < MiniTest::Spec
+class SkipUnchangedTest < Minitest::Spec
   module Model
     Song  = Struct.new(:title, :composer)
     Album = Struct.new(:name, :songs, :artist)

--- a/test/twin/struct_test.rb
+++ b/test/twin/struct_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 require 'disposable/twin/struct'
 
-class TwinStructTest < MiniTest::Spec
+class TwinStructTest < Minitest::Spec
   class Song < Disposable::Twin
     include Property::Struct
     property :number#, default: 1 # FIXME: this should be :default_if_nil so it becomes clear with a model.
@@ -54,7 +54,7 @@ class TwinStructTest < MiniTest::Spec
 end
 
 
-class TwinWithNestedStructTest < MiniTest::Spec
+class TwinWithNestedStructTest < Minitest::Spec
   class Song < Disposable::Twin
     property :title
     include Sync

--- a/test/twin/sync_option_test.rb
+++ b/test/twin/sync_option_test.rb
@@ -1,7 +1,7 @@
 # require 'test_helper'
 # require "disposable/twin/changed"
 
-# class SyncOptionTest < MiniTest::Spec
+# class SyncOptionTest < Minitest::Spec
 #   module Model
 #     Song  = Struct.new(:title, :composer)
 #     Album = Struct.new(:id, :name, :songs, :artist)
@@ -78,7 +78,7 @@
 # end
 
 
-# class SyncWithDynamicOptionsTest < MiniTest::Spec
+# class SyncWithDynamicOptionsTest < Minitest::Spec
 #   module Model
 #     Song  = Struct.new(:title, :composer)
 #     Album = Struct.new(:id, :name, :songs, :artist)
@@ -152,7 +152,7 @@
 # end
 
 
-# class SyncWithOptionsAndSkipUnchangedTest < MiniTest::Spec
+# class SyncWithOptionsAndSkipUnchangedTest < Minitest::Spec
 #   module Model
 #     Song  = Struct.new(:title, :composer)
 #     Album = Struct.new(:id, :name, :songs, :artist)
@@ -200,7 +200,7 @@
 # end
 
 # # :virtual wins over :sync
-# # class SyncWithVirtualTest < MiniTest::Spec
+# # class SyncWithVirtualTest < Minitest::Spec
 # #   Song = Struct.new(:title, :image, :band)
 # #   Band = Struct.new(:name)
 

--- a/test/twin/sync_test.rb
+++ b/test/twin/sync_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class TwinSyncTest < MiniTest::Spec
+class TwinSyncTest < Minitest::Spec
   module Model
     Song  = Struct.new(:title, :composer)
     Album = Struct.new(:name, :songs, :artist)

--- a/test/twin/twin_test.rb
+++ b/test/twin/twin_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TwinTest < MiniTest::Spec
+class TwinTest < Minitest::Spec
   module Model
     Song  = Struct.new(:id, :title, :album)
     Album = Struct.new(:id, :name, :songs, :artist)
@@ -114,7 +114,7 @@ class OverridingAccessorsTest < TwinTest
 end
 
 
-class TwinAsTest < MiniTest::Spec
+class TwinAsTest < Minitest::Spec
   module Model
     Song  = Struct.new(:title, :album)
     Album = Struct.new(:name)

--- a/test/twin/unnest_test.rb
+++ b/test/twin/unnest_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class UnnestTest < MiniTest::Spec
+class UnnestTest < Minitest::Spec
   class Twin < Disposable::Twin
     property :content do
       property :id, nice: "yes"

--- a/test/twin/virtual_test.rb
+++ b/test/twin/virtual_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class VirtualTest < MiniTest::Spec
+class VirtualTest < Minitest::Spec
   class CreditCardTwin < Disposable::Twin
     include Sync
     property :credit_card_number, virtual: true # no read, no write, it's virtual.

--- a/test/twin/writeable_test.rb
+++ b/test/twin/writeable_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class WriteableTest < MiniTest::Spec
+class WriteableTest < Minitest::Spec
   Credentials = Struct.new(:password, :credit_card) do
     def password=(v)
       raise "don't call me!"


### PR DESCRIPTION
Starting with ruby 3.4 ostruct will not be shipped with ruby by default. To avoid dependency issues we add ostruct as a dependency to our gemspec.